### PR TITLE
学習記録詳細ページ・編集機能の実装

### DIFF
--- a/app/components/StudyRecordCard.tsx
+++ b/app/components/StudyRecordCard.tsx
@@ -1,7 +1,19 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { css } from '../../styled-system/css';
 import { StudyRecord } from '../types/study-record';
 import { cardStyles, buttonStyles } from '../styles/components';
+import Link from 'next/link';
+import { supabase } from '../../lib/supabase';
+
+interface UserProfile {
+  user_id: string;
+  username?: string;
+  full_name?: string;
+  icon_url?: string;
+  bio?: string;
+  created_at: string;
+  updated_at: string;
+}
 
 interface StudyRecordCardProps {
   record: StudyRecord;
@@ -10,8 +22,12 @@ interface StudyRecordCardProps {
 
 export default function StudyRecordCard({ record, onDelete }: StudyRecordCardProps) {
   const [deleting, setDeleting] = useState(false);
+  const [authorProfile, setAuthorProfile] = useState<UserProfile | null>(null);
 
-  const handleDelete = async () => {
+  const handleDelete = async (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    
     if (!onDelete || !confirm('この学習記録を削除しますか？')) {
       return;
     }
@@ -26,6 +42,7 @@ export default function StudyRecordCard({ record, onDelete }: StudyRecordCardPro
       setDeleting(false);
     }
   };
+
   const formatDate = (date: Date) => {
     const now = new Date();
     const diffTime = Math.abs(now.getTime() - date.getTime());
@@ -60,207 +77,309 @@ export default function StudyRecordCard({ record, onDelete }: StudyRecordCardPro
 
   const subjectColor = getSubjectColor(record.subject);
 
+  // 投稿者のプロフィール情報を取得
+  useEffect(() => {
+    if (record.user_id && supabase) {
+      fetchAuthorProfile();
+    }
+  }, [record.user_id]);
+
+  const fetchAuthorProfile = async () => {
+    if (!supabase || !record.user_id) return;
+
+    try {
+      const { data, error } = await supabase
+        .from('user_profiles')
+        .select('*')
+        .eq('user_id', record.user_id)
+        .single();
+
+      if (!error && data) {
+        setAuthorProfile(data);
+      }
+    } catch (err) {
+      console.error('投稿者プロフィール取得エラー:', err);
+    }
+  };
+
+  // 投稿者の表示名を取得
+  const getAuthorDisplayName = () => {
+    if (authorProfile?.username) {
+      return authorProfile.username;
+    }
+    if (authorProfile?.full_name) {
+      return authorProfile.full_name;
+    }
+    if (record.user_name) {
+      return record.user_name;
+    }
+    if (record.user_email) {
+      return record.user_email;
+    }
+    return '不明なユーザー';
+  };
+
+  // 投稿者のアバターURLを取得
+  const getAuthorAvatarUrl = () => {
+    if (authorProfile?.icon_url) {
+      return authorProfile.icon_url;
+    }
+    return null;
+  };
+
+  // 投稿者のアバター初期文字を取得
+  const getAuthorAvatarInitial = () => {
+    const avatarUrl = getAuthorAvatarUrl();
+    if (avatarUrl) return '';
+
+    const displayName = getAuthorDisplayName();
+    if (displayName && displayName !== '不明なユーザー') {
+      return displayName[0].toUpperCase();
+    }
+    return 'U';
+  };
+
   return (
-    <div className={cardStyles.base}>
-      {/* Top accent line */}
-      <div className={css({
-        position: 'absolute',
-        top: '0',
-        left: '0',
-        right: '0',
-        height: '3px',
-        bg: 'gradient-to-r',
-        bgGradient: 'from-primary.600 to-primary.800'
-      })} />
-      
-      <div className={css({
-        display: 'flex',
-        flexDirection: 'column',
-        gap: '4'
+    <div className={css({
+      position: 'relative'
+    })}>
+      <Link href={`/studyList/${record.id}`} className={css({
+        textDecoration: 'none',
+        color: 'inherit',
+        display: 'block',
+        _hover: {
+          transform: 'translateY(-2px)',
+          transition: 'transform 0.2s ease-in-out'
+        }
       })}>
-        {/* Header */}
-        <div className={css({
-          display: 'flex',
-          justifyContent: 'space-between',
-          alignItems: 'flex-start',
-          gap: '3'
-        })}>
+        <div className={cardStyles.base}>
+          {/* Top accent line */}
+          <div className={css({
+            position: 'absolute',
+            top: '0',
+            left: '0',
+            right: '0',
+            height: '3px',
+            bg: 'gradient-to-r',
+            bgGradient: 'from-primary.600 to-primary.800'
+          })} />
+          
           <div className={css({
             display: 'flex',
             flexDirection: 'column',
-            gap: '2',
-            flex: '1'
+            gap: '4'
           })}>
+            {/* Header */}
             <div className={css({
               display: 'flex',
-              alignItems: 'center',
+              justifyContent: 'space-between',
+              alignItems: 'flex-start',
               gap: '3'
             })}>
-              <span className={css({
-                px: '3',
-                py: '1',
-                rounded: 'full',
-                fontSize: 'xs',
-                fontWeight: '600',
-                bg: subjectColor.bg,
-                color: subjectColor.text
+              <div className={css({
+                display: 'flex',
+                flexDirection: 'column',
+                gap: '2',
+                flex: '1'
               })}>
-                {record.subject}
-              </span>
-              <span className={css({
-                fontSize: 'xs',
-                color: 'gray.500',
-                fontWeight: '500'
-              })}>
-                {formatDate(record.createdAt)}
-              </span>
+                <div className={css({
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '3'
+                })}>
+                  <span className={css({
+                    px: '3',
+                    py: '1',
+                    rounded: 'full',
+                    fontSize: 'xs',
+                    fontWeight: '600',
+                    bg: subjectColor.bg,
+                    color: subjectColor.text
+                  })}>
+                    {record.subject}
+                  </span>
+                  <span className={css({
+                    fontSize: 'xs',
+                    color: 'gray.500',
+                    fontWeight: '500'
+                  })}>
+                    {formatDate(record.createdAt)}
+                  </span>
+                </div>
+                
+                {/* 投稿者情報 */}
+                <div className={css({
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '2'
+                })}>
+                  <div className={css({
+                    w: '4',
+                    h: '4',
+                    rounded: 'full',
+                    bg: 'blue.100',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    fontSize: 'xs',
+                    fontWeight: 'medium',
+                    color: 'blue.600',
+                    overflow: 'hidden'
+                  })}>
+                    {getAuthorAvatarUrl() ? (
+                      <img
+                        src={getAuthorAvatarUrl()!}
+                        alt="投稿者アバター"
+                        className={css({
+                          w: 'full',
+                          h: 'full',
+                          objectFit: 'cover'
+                        })}
+                      />
+                    ) : (
+                      getAuthorAvatarInitial()
+                    )}
+                  </div>
+                  <span className={css({
+                    fontSize: 'xs',
+                    color: 'gray.600',
+                    fontWeight: '500'
+                  })}>
+                    {getAuthorDisplayName()}
+                  </span>
+                </div>
+              </div>
             </div>
-            
-            {/* 投稿者情報 */}
+
+            {/* Duration */}
             <div className={css({
               display: 'flex',
               alignItems: 'center',
               gap: '2'
             })}>
               <span className={css({
-                fontSize: 'xs',
+                fontSize: 'sm',
                 color: 'gray.400'
               })}>
-                👤
+                ⏱️
               </span>
               <span className={css({
-                fontSize: 'xs',
-                color: 'gray.600',
-                fontWeight: '500'
+                fontSize: 'lg',
+                fontWeight: 'bold',
+                color: 'primary.700'
               })}>
-                {record.user_name || record.user_email || '不明なユーザー'}
-              </span>
-            </div>
-          </div>
-        </div>
-
-        {/* Duration */}
-        <div className={css({
-          display: 'flex',
-          alignItems: 'center',
-          gap: '2'
-        })}>
-          <span className={css({
-            fontSize: 'sm',
-            color: 'gray.400'
-          })}>
-            ⏱️
-          </span>
-          <span className={css({
-            fontSize: 'lg',
-            fontWeight: 'bold',
-            color: 'primary.700'
-          })}>
-            {record.duration}分
-          </span>
-        </div>
-        
-        {/* Notes */}
-        {record.notes && (
-          <p className={css({
-            fontSize: 'sm',
-            color: 'gray.600',
-            lineHeight: 'relaxed',
-            whiteSpace: 'pre-wrap',
-            bg: 'gray.50',
-            p: '3',
-            rounded: 'md',
-            border: '1px solid',
-            borderColor: 'gray.200'
-          })}>
-            {record.notes}
-          </p>
-        )}
-
-        {/* Footer */}
-        <div className={css({
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'space-between',
-          pt: '3',
-          borderTop: '1px solid',
-          borderColor: 'gray.100'
-        })}>
-          <div className={css({
-            display: 'flex',
-            alignItems: 'center',
-            gap: '2'
-          })}>
-            <span className={css({
-              fontSize: 'xs',
-              color: 'gray.400'
-            })}>
-              📚
-            </span>
-            <span className={css({
-              fontSize: 'xs',
-              color: 'gray.500'
-            })}>
-              学習記録
-            </span>
-          </div>
-          
-          <div className={css({
-            display: 'flex',
-            alignItems: 'center',
-            gap: '3'
-          })}>
-            <div className={css({
-              display: 'flex',
-              alignItems: 'center',
-              gap: '1'
-            })}>
-              <div className={css({
-                w: '2',
-                h: '2',
-                bg: 'green.400',
-                rounded: 'full'
-              })} />
-              <span className={css({
-                fontSize: 'xs',
-                color: 'gray.500'
-              })}>
-                完了
+                {record.duration}分
               </span>
             </div>
             
-            {onDelete && (
-              <button
-                onClick={handleDelete}
-                disabled={deleting}
-                className={css({
-                  px: '2',
-                  py: '1',
-                  bg: 'red.50',
-                  color: 'red.600',
-                  rounded: 'md',
-                  fontSize: 'xs',
-                  fontWeight: 'medium',
-                  border: '1px solid',
-                  borderColor: 'red.200',
-                  cursor: 'pointer',
-                  transition: 'all 0.2s',
-                  _hover: {
-                    bg: 'red.100',
-                    borderColor: 'red.300'
-                  },
-                  _disabled: {
-                    opacity: '0.5',
-                    cursor: 'not-allowed'
-                  }
-                })}
-              >
-                {deleting ? '削除中...' : '削除'}
-              </button>
+            {/* Notes */}
+            {record.notes && (
+              <p className={css({
+                fontSize: 'sm',
+                color: 'gray.600',
+                lineHeight: 'relaxed',
+                whiteSpace: 'pre-wrap',
+                bg: 'gray.50',
+                p: '3',
+                rounded: 'md',
+                border: '1px solid',
+                borderColor: 'gray.200'
+              })}>
+                {record.notes}
+              </p>
             )}
+
+            {/* Footer */}
+            <div className={css({
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              pt: '3',
+              borderTop: '1px solid',
+              borderColor: 'gray.100'
+            })}>
+              <div className={css({
+                display: 'flex',
+                alignItems: 'center',
+                gap: '2'
+              })}>
+                <span className={css({
+                  fontSize: 'xs',
+                  color: 'gray.400'
+                })}>
+                  📚
+                </span>
+                <span className={css({
+                  fontSize: 'xs',
+                  color: 'gray.500'
+                })}>
+                  学習記録
+                </span>
+              </div>
+              
+              <div className={css({
+                display: 'flex',
+                alignItems: 'center',
+                gap: '3'
+              })}>
+                <div className={css({
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '1'
+                })}>
+                  <div className={css({
+                    w: '2',
+                    h: '2',
+                    bg: 'green.400',
+                    rounded: 'full'
+                  })} />
+                  <span className={css({
+                    fontSize: 'xs',
+                    color: 'gray.500'
+                  })}>
+                    完了
+                  </span>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
-      </div>
+      </Link>
+      
+      {/* 削除ボタン - Linkの外に配置 */}
+      {onDelete && (
+        <button
+          onClick={handleDelete}
+          disabled={deleting}
+          className={css({
+            position: 'absolute',
+            top: '2',
+            right: '2',
+            px: '2',
+            py: '1',
+            bg: 'red.50',
+            color: 'red.600',
+            rounded: 'md',
+            fontSize: 'xs',
+            fontWeight: 'medium',
+            border: '1px solid',
+            borderColor: 'red.200',
+            cursor: 'pointer',
+            transition: 'all 0.2s',
+            zIndex: '10',
+            _hover: {
+              bg: 'red.100',
+              borderColor: 'red.300'
+            },
+            _disabled: {
+              opacity: '0.5',
+              cursor: 'not-allowed'
+            }
+          })}
+        >
+          {deleting ? '削除中...' : '削除'}
+        </button>
+      )}
     </div>
   );
 } 

--- a/app/components/StudyRecordCard.tsx
+++ b/app/components/StudyRecordCard.tsx
@@ -63,16 +63,25 @@ export default function StudyRecordCard({ record, onDelete }: StudyRecordCardPro
   };
 
   const getSubjectColor = (subject: string) => {
-    const colors = {
-      '数学': { bg: 'primary.100', text: 'accent.math' },
-      '英語': { bg: 'primary.100', text: 'accent.english' },
-      '国語': { bg: 'red.100', text: 'red.700' },
-      '理科': { bg: 'primary.100', text: 'accent.science' },
-      '社会': { bg: 'primary.100', text: 'accent.social' },
-      'プログラミング': { bg: 'primary.100', text: 'accent.programming' },
-    };
+    // 科目名からハッシュ値を生成して色を決定
+    const hash = subject.split('').reduce((acc, char) => {
+      return char.charCodeAt(0) + ((acc << 5) - acc);
+    }, 0);
     
-    return colors[subject as keyof typeof colors] || { bg: 'primary.100', text: 'accent.other' };
+    // ハッシュ値から色のインデックスを決定
+    const colorIndex = Math.abs(hash) % 6;
+    
+    // 色のパレット（6色）
+    const colorPalette = [
+      { bg: 'blue.100', text: 'blue.700' },
+      { bg: 'green.100', text: 'green.700' },
+      { bg: 'purple.100', text: 'purple.700' },
+      { bg: 'orange.100', text: 'orange.700' },
+      { bg: 'pink.100', text: 'pink.700' },
+      { bg: 'teal.100', text: 'teal.700' }
+    ];
+    
+    return colorPalette[colorIndex];
   };
 
   const subjectColor = getSubjectColor(record.subject);

--- a/app/components/StudyRecordForm.tsx
+++ b/app/components/StudyRecordForm.tsx
@@ -64,8 +64,7 @@ export default function StudyRecordForm({ onSubmit }: StudyRecordFormProps) {
         left: '0',
         right: '0',
         height: '4px',
-        bg: 'gradient-to-r',
-        bgGradient: 'from-primary.600 to-primary.800',
+        bg: 'primary.700',
         roundedTop: '2xl'
       }
     })}>
@@ -151,8 +150,7 @@ export default function StudyRecordForm({ onSubmit }: StudyRecordFormProps) {
           disabled={loading}
           className={css({
             w: 'full',
-            bg: 'gradient-to-r',
-            bgGradient: 'from-primary.600 to-primary.800',
+            bg: 'primary.700',
             color: 'white',
             py: '3',
             px: '6',
@@ -161,6 +159,7 @@ export default function StudyRecordForm({ onSubmit }: StudyRecordFormProps) {
             fontSize: 'sm',
             transition: 'all 0.2s',
             _hover: {
+              bg: 'primary.800',
               transform: 'translateY(-1px)',
               shadow: 'lg'
             },

--- a/app/hooks/useStudyRecords.ts
+++ b/app/hooks/useStudyRecords.ts
@@ -127,6 +127,13 @@ export function useStudyRecords() {
         throw error;
       }
 
+      // ユーザープロフィール情報を取得
+      const { data: profileData } = await supabase
+        .from('user_profiles')
+        .select('username, full_name')
+        .eq('user_id', user.id)
+        .single();
+
       // Supabaseのデータ形式をアプリケーションの型に変換
       const formattedRecords: StudyRecord[] = (data || []).map(record => ({
         id: record.id,
@@ -137,7 +144,7 @@ export function useStudyRecords() {
         updatedAt: new Date(record.updated_at),
         user_id: record.user_id,
         user_email: user.email,
-        user_name: user.user_metadata?.full_name
+        user_name: profileData?.username || profileData?.full_name || user.user_metadata?.full_name
       }));
 
       setRecords(formattedRecords);
@@ -207,6 +214,13 @@ export function useStudyRecords() {
         throw error;
       }
 
+      // ユーザープロフィール情報を取得
+      const { data: profileData } = await supabase
+        .from('user_profiles')
+        .select('username, full_name')
+        .eq('user_id', user.id)
+        .single();
+
       // 新しいレコードをアプリケーションの型に変換
       const formattedRecord: StudyRecord = {
         id: data.id,
@@ -217,7 +231,7 @@ export function useStudyRecords() {
         updatedAt: new Date(data.updated_at),
         user_id: data.user_id,
         user_email: user.email,
-        user_name: user.user_metadata?.full_name
+        user_name: profileData?.username || profileData?.full_name || user.user_metadata?.full_name
       };
 
       // ローカル状態を更新

--- a/app/studyList/[id]/edit/page.tsx
+++ b/app/studyList/[id]/edit/page.tsx
@@ -1,0 +1,525 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter, useParams } from 'next/navigation';
+import { css } from '../../../../styled-system/css';
+import { useAuth } from '../../../hooks/useAuth';
+import { supabase } from '../../../../lib/supabase';
+import LoadingSpinner from '../../../components/ui/LoadingSpinner';
+import ErrorMessage from '../../../components/ui/ErrorMessage';
+import { StudyRecord, CreateStudyRecord } from '../../../types/study-record';
+
+export default function StudyRecordEditPage() {
+  const { user, loading: authLoading } = useAuth();
+  const router = useRouter();
+  const params = useParams();
+  const recordId = params.id as string;
+  
+  const [record, setRecord] = useState<StudyRecord | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [formData, setFormData] = useState<CreateStudyRecord>({
+    subject: '',
+    duration: 0,
+    notes: ''
+  });
+
+  useEffect(() => {
+    if (!authLoading && !user) {
+      router.push('/');
+    }
+  }, [user, authLoading, router]);
+
+  useEffect(() => {
+    if (user && recordId) {
+      fetchRecord();
+    }
+  }, [user, recordId]);
+
+  const fetchRecord = async () => {
+    if (!supabase || !user || !recordId) return;
+
+    try {
+      setLoading(true);
+      setError(null);
+
+      // 学習記録を取得
+      const { data: recordData, error: recordError } = await supabase
+        .from('study_records')
+        .select('*')
+        .eq('id', recordId)
+        .single();
+
+      if (recordError) {
+        if (recordError.code === 'PGRST116') {
+          setError('学習記録が見つかりません');
+        } else {
+          setError('学習記録の取得に失敗しました');
+        }
+        return;
+      }
+
+      if (recordData) {
+        // 自分の学習記録かチェック
+        if (recordData.user_id !== user.id) {
+          setError('この学習記録を編集する権限がありません');
+          return;
+        }
+
+        const studyRecord: StudyRecord = {
+          id: recordData.id,
+          subject: recordData.subject,
+          duration: recordData.duration,
+          notes: recordData.notes,
+          createdAt: new Date(recordData.created_at),
+          updatedAt: new Date(recordData.updated_at),
+          user_id: recordData.user_id,
+          user_email: recordData.user_email,
+          user_name: recordData.user_name
+        };
+        setRecord(studyRecord);
+        setFormData({
+          subject: studyRecord.subject,
+          duration: studyRecord.duration,
+          notes: studyRecord.notes || ''
+        });
+      }
+    } catch (err) {
+      console.error('学習記録取得エラー:', err);
+      setError('学習記録の取得に失敗しました');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!supabase || !user || !record) return;
+
+    try {
+      setSaving(true);
+      setError('');
+
+      const { error } = await supabase
+        .from('study_records')
+        .update({
+          subject: formData.subject,
+          duration: formData.duration,
+          notes: formData.notes,
+          updated_at: new Date().toISOString()
+        })
+        .eq('id', record.id);
+
+      if (error) throw error;
+
+      // 詳細ページにリダイレクト
+      router.push(`/studyList/${record.id}`);
+    } catch (err) {
+      console.error('更新エラー:', err);
+      setError('学習記録の更新に失敗しました');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleCancel = () => {
+    router.push(`/studyList/${recordId}`);
+  };
+
+  if (authLoading || loading) {
+    return (
+      <div className={css({
+        minH: '100vh',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center'
+      })}>
+        <LoadingSpinner />
+      </div>
+    );
+  }
+
+  if (!user) {
+    return (
+      <div className={css({
+        minH: '100vh',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        bg: 'gray.50'
+      })}>
+        <div className={css({
+          textAlign: 'center',
+          p: '8'
+        })}>
+          <div className={css({
+            w: '16',
+            h: '16',
+            bg: 'red.100',
+            rounded: 'full',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            mx: 'auto',
+            mb: '4'
+          })}>
+            <span className={css({
+              fontSize: '2xl'
+            })}>
+              🔒
+            </span>
+          </div>
+          <h2 className={css({
+            fontSize: 'xl',
+            fontWeight: 'bold',
+            color: 'gray.900',
+            mb: '2'
+          })}>
+            アクセスが拒否されました
+          </h2>
+          <p className={css({
+            color: 'gray.600',
+            mb: '4'
+          })}>
+            このページにアクセスするにはログインが必要です
+          </p>
+          <button
+            onClick={() => router.push('/')}
+            className={css({
+              px: '4',
+              py: '2',
+              bg: 'blue.600',
+              color: 'white',
+              rounded: 'md',
+              fontSize: 'sm',
+              fontWeight: 'medium',
+              _hover: {
+                bg: 'blue.700'
+              }
+            })}
+          >
+            ログインページに戻る
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className={css({
+        maxW: '4xl',
+        mx: 'auto',
+        px: '6',
+        py: '8'
+      })}>
+        <ErrorMessage
+          title="エラーが発生しました"
+          message={error}
+          type="error"
+          actions={
+            <button
+              onClick={() => router.push('/studyList')}
+              className={css({
+                px: '4',
+                py: '2',
+                bg: 'blue.600',
+                color: 'white',
+                rounded: 'md',
+                fontSize: 'sm',
+                fontWeight: 'medium',
+                _hover: {
+                  bg: 'blue.700'
+                }
+              })}
+            >
+              学習記録一覧に戻る
+            </button>
+          }
+        />
+      </div>
+    );
+  }
+
+  if (!record) {
+    return (
+      <div className={css({
+        maxW: '4xl',
+        mx: 'auto',
+        px: '6',
+        py: '8'
+      })}>
+        <ErrorMessage
+          title="学習記録が見つかりません"
+          message="指定された学習記録は存在しないか、削除された可能性があります。"
+          type="warning"
+          actions={
+            <button
+              onClick={() => router.push('/studyList')}
+              className={css({
+                px: '4',
+                py: '2',
+                bg: 'blue.600',
+                color: 'white',
+                rounded: 'md',
+                fontSize: 'sm',
+                fontWeight: 'medium',
+                _hover: {
+                  bg: 'blue.700'
+                }
+              })}
+            >
+              学習記録一覧に戻る
+            </button>
+          }
+        />
+      </div>
+    );
+  }
+
+  return (
+    <main className={css({
+      maxW: '4xl',
+      mx: 'auto',
+      px: '6',
+      py: '8'
+    })}>
+      {/* ヘッダー */}
+      <div className={css({
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        mb: '6'
+      })}>
+        <button
+          onClick={() => router.push(`/studyList/${recordId}`)}
+          className={css({
+            display: 'flex',
+            alignItems: 'center',
+            gap: '2',
+            px: '3',
+            py: '2',
+            bg: 'gray.100',
+            color: 'gray.700',
+            rounded: 'md',
+            fontSize: 'sm',
+            fontWeight: 'medium',
+            _hover: {
+              bg: 'gray.200'
+            }
+          })}
+        >
+          ← 詳細に戻る
+        </button>
+      </div>
+
+      {/* 編集フォーム */}
+      <div className={css({
+        bg: 'white',
+        rounded: '2xl',
+        shadow: 'lg',
+        border: '1px solid',
+        borderColor: 'gray.100',
+        overflow: 'hidden'
+      })}>
+        {/* トップアクセントライン */}
+        <div className={css({
+          height: '4px',
+          bg: 'gradient-to-r',
+          bgGradient: 'from-blue.600 to-blue.800'
+        })} />
+
+        <div className={css({
+          p: '8'
+        })}>
+          <div className={css({
+            mb: '8'
+          })}>
+            <h1 className={css({
+              fontSize: '3xl',
+              fontWeight: 'bold',
+              color: 'gray.900',
+              mb: '2'
+            })}>
+              学習記録を編集
+            </h1>
+            <p className={css({
+              fontSize: 'lg',
+              color: 'gray.600'
+            })}>
+              学習内容を修正しましょう
+            </p>
+          </div>
+
+          <form onSubmit={handleSubmit} className={css({
+            spaceY: '6'
+          })}>
+            {/* 科目 */}
+            <div>
+              <label className={css({
+                display: 'block',
+                fontSize: 'sm',
+                fontWeight: '600',
+                color: 'gray.700',
+                mb: '2'
+              })}>
+                科目 *
+              </label>
+              <input
+                type="text"
+                value={formData.subject}
+                onChange={(e) => setFormData(prev => ({ ...prev, subject: e.target.value }))}
+                required
+                className={css({
+                  w: 'full',
+                  px: '4',
+                  py: '3',
+                  border: '1px solid',
+                  borderColor: 'gray.300',
+                  rounded: 'lg',
+                  fontSize: 'md',
+                  _focus: {
+                    outline: 'none',
+                    ring: '2px',
+                    ringColor: 'blue.500',
+                    borderColor: 'blue.500'
+                  }
+                })}
+                placeholder="例: 数学、英語、プログラミング"
+              />
+            </div>
+
+            {/* 学習時間 */}
+            <div>
+              <label className={css({
+                display: 'block',
+                fontSize: 'sm',
+                fontWeight: '600',
+                color: 'gray.700',
+                mb: '2'
+              })}>
+                学習時間（分） *
+              </label>
+              <input
+                type="number"
+                value={formData.duration}
+                onChange={(e) => setFormData(prev => ({ ...prev, duration: parseInt(e.target.value) || 0 }))}
+                required
+                min="1"
+                max="1440"
+                className={css({
+                  w: 'full',
+                  px: '4',
+                  py: '3',
+                  border: '1px solid',
+                  borderColor: 'gray.300',
+                  rounded: 'lg',
+                  fontSize: 'md',
+                  _focus: {
+                    outline: 'none',
+                    ring: '2px',
+                    ringColor: 'blue.500',
+                    borderColor: 'blue.500'
+                  }
+                })}
+                placeholder="例: 60"
+              />
+            </div>
+
+            {/* 学習内容 */}
+            <div>
+              <label className={css({
+                display: 'block',
+                fontSize: 'sm',
+                fontWeight: '600',
+                color: 'gray.700',
+                mb: '2'
+              })}>
+                学習内容
+              </label>
+              <textarea
+                value={formData.notes}
+                onChange={(e) => setFormData(prev => ({ ...prev, notes: e.target.value }))}
+                rows={6}
+                className={css({
+                  w: 'full',
+                  px: '4',
+                  py: '3',
+                  border: '1px solid',
+                  borderColor: 'gray.300',
+                  rounded: 'lg',
+                  fontSize: 'md',
+                  resize: 'vertical',
+                  _focus: {
+                    outline: 'none',
+                    ring: '2px',
+                    ringColor: 'blue.500',
+                    borderColor: 'blue.500'
+                  }
+                })}
+                placeholder="学習した内容や感想を記録しましょう"
+              />
+            </div>
+
+            {/* ボタン */}
+            <div className={css({
+              display: 'flex',
+              gap: '4',
+              pt: '6',
+              borderTop: '1px solid',
+              borderColor: 'gray.200'
+            })}>
+              <button
+                type="button"
+                onClick={handleCancel}
+                className={css({
+                  px: '6',
+                  py: '3',
+                  bg: 'gray.100',
+                  color: 'gray.700',
+                  rounded: 'lg',
+                  fontSize: 'md',
+                  fontWeight: 'medium',
+                  border: 'none',
+                  cursor: 'pointer',
+                  transition: 'all 0.2s',
+                  _hover: {
+                    bg: 'gray.200'
+                  }
+                })}
+              >
+                キャンセル
+              </button>
+              <button
+                type="submit"
+                disabled={saving || !formData.subject || formData.duration <= 0}
+                className={css({
+                  px: '6',
+                  py: '3',
+                  bg: 'blue.600',
+                  color: 'white',
+                  rounded: 'lg',
+                  fontSize: 'md',
+                  fontWeight: 'medium',
+                  border: 'none',
+                  cursor: 'pointer',
+                  transition: 'all 0.2s',
+                  _hover: {
+                    bg: 'blue.700'
+                  },
+                  _disabled: {
+                    opacity: '0.5',
+                    cursor: 'not-allowed'
+                  }
+                })}
+              >
+                {saving ? '更新中...' : '更新する'}
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </main>
+  );
+} 

--- a/app/studyList/[id]/page.tsx
+++ b/app/studyList/[id]/page.tsx
@@ -1,0 +1,653 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter, useParams } from 'next/navigation';
+import { css } from '../../../styled-system/css';
+import { useAuth } from '../../hooks/useAuth';
+import { supabase } from '../../../lib/supabase';
+import LoadingSpinner from '../../components/ui/LoadingSpinner';
+import ErrorMessage from '../../components/ui/ErrorMessage';
+import { StudyRecord } from '../../types/study-record';
+
+interface UserProfile {
+  user_id: string;
+  username?: string;
+  full_name?: string;
+  icon_url?: string;
+  bio?: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export default function StudyRecordDetailPage() {
+  const { user, loading: authLoading } = useAuth();
+  const router = useRouter();
+  const params = useParams();
+  const recordId = params.id as string;
+  
+  const [record, setRecord] = useState<StudyRecord | null>(null);
+  const [authorProfile, setAuthorProfile] = useState<UserProfile | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [deleting, setDeleting] = useState(false);
+
+  useEffect(() => {
+    if (!authLoading && !user) {
+      router.push('/');
+    }
+  }, [user, authLoading, router]);
+
+  useEffect(() => {
+    if (user && recordId) {
+      fetchRecord();
+    }
+  }, [user, recordId]);
+
+  const fetchRecord = async () => {
+    if (!supabase || !user || !recordId) return;
+
+    try {
+      setLoading(true);
+      setError(null);
+
+      // 学習記録を取得
+      const { data: recordData, error: recordError } = await supabase
+        .from('study_records')
+        .select('*')
+        .eq('id', recordId)
+        .single();
+
+      if (recordError) {
+        if (recordError.code === 'PGRST116') {
+          setError('学習記録が見つかりません');
+        } else {
+          setError('学習記録の取得に失敗しました');
+        }
+        return;
+      }
+
+      if (recordData) {
+        const studyRecord: StudyRecord = {
+          id: recordData.id,
+          subject: recordData.subject,
+          duration: recordData.duration,
+          notes: recordData.notes,
+          createdAt: new Date(recordData.created_at),
+          updatedAt: new Date(recordData.updated_at),
+          user_id: recordData.user_id,
+          user_email: recordData.user_email,
+          user_name: recordData.user_name
+        };
+        setRecord(studyRecord);
+
+        // 投稿者のプロフィール情報を取得
+        await fetchAuthorProfile(recordData.user_id);
+      }
+    } catch (err) {
+      console.error('学習記録取得エラー:', err);
+      setError('学習記録の取得に失敗しました');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const fetchAuthorProfile = async (authorId: string) => {
+    if (!supabase) return;
+
+    try {
+      const { data, error } = await supabase
+        .from('user_profiles')
+        .select('*')
+        .eq('user_id', authorId)
+        .single();
+
+      if (!error && data) {
+        setAuthorProfile(data);
+      }
+    } catch (err) {
+      console.error('投稿者プロフィール取得エラー:', err);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!record || !supabase || !confirm('この学習記録を削除しますか？')) {
+      return;
+    }
+
+    setDeleting(true);
+    try {
+      const { error } = await supabase
+        .from('study_records')
+        .delete()
+        .eq('id', record.id);
+
+      if (error) {
+        throw error;
+      }
+
+      router.push('/studyList');
+    } catch (err) {
+      console.error('削除エラー:', err);
+      alert('削除に失敗しました');
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  const formatDate = (date: Date) => {
+    return new Intl.DateTimeFormat('ja-JP', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit'
+    }).format(date);
+  };
+
+  const getSubjectColor = (subject: string) => {
+    const colors = {
+      '数学': { bg: 'primary.100', text: 'accent.math' },
+      '英語': { bg: 'primary.100', text: 'accent.english' },
+      '国語': { bg: 'red.100', text: 'red.700' },
+      '理科': { bg: 'primary.100', text: 'accent.science' },
+      '社会': { bg: 'primary.100', text: 'accent.social' },
+      'プログラミング': { bg: 'primary.100', text: 'accent.programming' },
+    };
+    
+    return colors[subject as keyof typeof colors] || { bg: 'primary.100', text: 'accent.other' };
+  };
+
+  // 投稿者の表示名を取得
+  const getAuthorDisplayName = () => {
+    if (authorProfile?.username) {
+      return authorProfile.username;
+    }
+    if (authorProfile?.full_name) {
+      return authorProfile.full_name;
+    }
+    if (record?.user_name) {
+      return record.user_name;
+    }
+    if (record?.user_email) {
+      return record.user_email;
+    }
+    return '不明なユーザー';
+  };
+
+  // 投稿者のアバターURLを取得
+  const getAuthorAvatarUrl = () => {
+    if (authorProfile?.icon_url) {
+      return authorProfile.icon_url;
+    }
+    return null;
+  };
+
+  // 投稿者のアバター初期文字を取得
+  const getAuthorAvatarInitial = () => {
+    const avatarUrl = getAuthorAvatarUrl();
+    if (avatarUrl) return null;
+
+    const displayName = getAuthorDisplayName();
+    if (displayName && displayName !== '不明なユーザー') {
+      return displayName[0].toUpperCase();
+    }
+    return 'U';
+  };
+
+  if (authLoading || loading) {
+    return (
+      <div className={css({
+        minH: '100vh',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center'
+      })}>
+        <LoadingSpinner />
+      </div>
+    );
+  }
+
+  if (!user) {
+    return (
+      <div className={css({
+        minH: '100vh',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        bg: 'gray.50'
+      })}>
+        <div className={css({
+          textAlign: 'center',
+          p: '8'
+        })}>
+          <div className={css({
+            w: '16',
+            h: '16',
+            bg: 'red.100',
+            rounded: 'full',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            mx: 'auto',
+            mb: '4'
+          })}>
+            <span className={css({
+              fontSize: '2xl'
+            })}>
+              🔒
+            </span>
+          </div>
+          <h2 className={css({
+            fontSize: 'xl',
+            fontWeight: 'bold',
+            color: 'gray.900',
+            mb: '2'
+          })}>
+            アクセスが拒否されました
+          </h2>
+          <p className={css({
+            color: 'gray.600',
+            mb: '4'
+          })}>
+            このページにアクセスするにはログインが必要です
+          </p>
+          <button
+            onClick={() => router.push('/')}
+            className={css({
+              px: '4',
+              py: '2',
+              bg: 'blue.600',
+              color: 'white',
+              rounded: 'md',
+              fontSize: 'sm',
+              fontWeight: 'medium',
+              _hover: {
+                bg: 'blue.700'
+              }
+            })}
+          >
+            ログインページに戻る
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className={css({
+        maxW: '4xl',
+        mx: 'auto',
+        px: '6',
+        py: '8'
+      })}>
+        <ErrorMessage
+          title="エラーが発生しました"
+          message={error}
+          type="error"
+          actions={
+            <button
+              onClick={() => router.push('/studyList')}
+              className={css({
+                px: '4',
+                py: '2',
+                bg: 'blue.600',
+                color: 'white',
+                rounded: 'md',
+                fontSize: 'sm',
+                fontWeight: 'medium',
+                _hover: {
+                  bg: 'blue.700'
+                }
+              })}
+            >
+              学習記録一覧に戻る
+            </button>
+          }
+        />
+      </div>
+    );
+  }
+
+  if (!record) {
+    return (
+      <div className={css({
+        maxW: '4xl',
+        mx: 'auto',
+        px: '6',
+        py: '8'
+      })}>
+        <ErrorMessage
+          title="学習記録が見つかりません"
+          message="指定された学習記録は存在しないか、削除された可能性があります。"
+          type="warning"
+          actions={
+            <button
+              onClick={() => router.push('/studyList')}
+              className={css({
+                px: '4',
+                py: '2',
+                bg: 'blue.600',
+                color: 'white',
+                rounded: 'md',
+                fontSize: 'sm',
+                fontWeight: 'medium',
+                _hover: {
+                  bg: 'blue.700'
+                }
+              })}
+            >
+              学習記録一覧に戻る
+            </button>
+          }
+        />
+      </div>
+    );
+  }
+
+  const subjectColor = getSubjectColor(record.subject);
+
+  return (
+    <main className={css({
+      maxW: '4xl',
+      mx: 'auto',
+      px: '6',
+      py: '8'
+    })}>
+      {/* ヘッダー */}
+      <div className={css({
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        mb: '6'
+      })}>
+        <button
+          onClick={() => router.push('/studyList')}
+          className={css({
+            display: 'flex',
+            alignItems: 'center',
+            gap: '2',
+            px: '3',
+            py: '2',
+            bg: 'gray.100',
+            color: 'gray.700',
+            rounded: 'md',
+            fontSize: 'sm',
+            fontWeight: 'medium',
+            _hover: {
+              bg: 'gray.200'
+            }
+          })}
+        >
+          ← 一覧に戻る
+        </button>
+        
+        {user.id === record.user_id && (
+          <div className={css({
+            display: 'flex',
+            gap: '3'
+          })}>
+            <button
+              onClick={() => router.push(`/studyList/${record.id}/edit`)}
+              className={css({
+                px: '4',
+                py: '2',
+                bg: 'blue.600',
+                color: 'white',
+                rounded: 'md',
+                fontSize: 'sm',
+                fontWeight: 'medium',
+                _hover: {
+                  bg: 'blue.700'
+                }
+              })}
+            >
+              編集
+            </button>
+            <button
+              onClick={handleDelete}
+              disabled={deleting}
+              className={css({
+                px: '4',
+                py: '2',
+                bg: 'red.600',
+                color: 'white',
+                rounded: 'md',
+                fontSize: 'sm',
+                fontWeight: 'medium',
+                _hover: {
+                  bg: 'red.700'
+                },
+                _disabled: {
+                  opacity: '0.5',
+                  cursor: 'not-allowed'
+                }
+              })}
+            >
+              {deleting ? '削除中...' : '削除'}
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* 学習記録詳細 */}
+      <div className={css({
+        bg: 'white',
+        rounded: '2xl',
+        shadow: 'lg',
+        border: '1px solid',
+        borderColor: 'gray.100',
+        overflow: 'hidden'
+      })}>
+        {/* トップアクセントライン */}
+        <div className={css({
+          height: '4px',
+          bg: 'gradient-to-r',
+          bgGradient: 'from-primary.600 to-primary.800'
+        })} />
+
+        <div className={css({
+          p: '8'
+        })}>
+          {/* ヘッダー情報 */}
+          <div className={css({
+            display: 'flex',
+            alignItems: 'flex-start',
+            justifyContent: 'space-between',
+            mb: '6'
+          })}>
+            <div className={css({
+              flex: '1'
+            })}>
+              <div className={css({
+                display: 'flex',
+                alignItems: 'center',
+                gap: '3',
+                mb: '4'
+              })}>
+                <span className={css({
+                  px: '4',
+                  py: '2',
+                  rounded: 'full',
+                  fontSize: 'sm',
+                  fontWeight: '600',
+                  bg: subjectColor.bg,
+                  color: subjectColor.text
+                })}>
+                  {record.subject}
+                </span>
+                <span className={css({
+                  fontSize: 'sm',
+                  color: 'gray.500',
+                  fontWeight: '500'
+                })}>
+                  {formatDate(record.createdAt)}
+                </span>
+              </div>
+
+              {/* 投稿者情報 */}
+              <div className={css({
+                display: 'flex',
+                alignItems: 'center',
+                gap: '3',
+                mb: '6'
+              })}>
+                <div className={css({
+                  w: '10',
+                  h: '10',
+                  rounded: 'full',
+                  bg: 'blue.100',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  fontSize: 'sm',
+                  fontWeight: 'medium',
+                  color: 'blue.600',
+                  overflow: 'hidden'
+                })}>
+                  {getAuthorAvatarUrl() ? (
+                    <img
+                      src={getAuthorAvatarUrl()}
+                      alt="投稿者アバター"
+                      className={css({
+                        w: 'full',
+                        h: 'full',
+                        objectFit: 'cover'
+                      })}
+                    />
+                  ) : (
+                    getAuthorAvatarInitial()
+                  )}
+                </div>
+                <div className={css({
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: '1'
+                })}>
+                  <span className={css({
+                    fontSize: 'lg',
+                    fontWeight: '600',
+                    color: 'gray.900'
+                  })}>
+                    {getAuthorDisplayName()}
+                  </span>
+                  <span className={css({
+                    fontSize: 'sm',
+                    color: 'gray.500'
+                  })}>
+                    投稿者
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* 学習時間 */}
+          <div className={css({
+            display: 'flex',
+            alignItems: 'center',
+            gap: '3',
+            mb: '6',
+            p: '4',
+            bg: 'primary.50',
+            rounded: 'lg',
+            border: '1px solid',
+            borderColor: 'primary.200'
+          })}>
+            <span className={css({
+              fontSize: 'xl',
+              color: 'primary.600'
+            })}>
+              ⏱️
+            </span>
+            <div className={css({
+              display: 'flex',
+              flexDirection: 'column',
+              gap: '1'
+            })}>
+              <span className={css({
+                fontSize: '2xl',
+                fontWeight: 'bold',
+                color: 'primary.700'
+              })}>
+                {record.duration}分
+              </span>
+              <span className={css({
+                fontSize: 'sm',
+                color: 'primary.600'
+              })}>
+                学習時間
+              </span>
+            </div>
+          </div>
+
+          {/* 学習内容 */}
+          {record.notes && (
+            <div className={css({
+              mb: '6'
+            })}>
+              <h3 className={css({
+                fontSize: 'lg',
+                fontWeight: '600',
+                color: 'gray.900',
+                mb: '3'
+              })}>
+                学習内容
+              </h3>
+              <div className={css({
+                p: '4',
+                bg: 'gray.50',
+                rounded: 'lg',
+                border: '1px solid',
+                borderColor: 'gray.200'
+              })}>
+                <p className={css({
+                  fontSize: 'md',
+                  color: 'gray.700',
+                  lineHeight: 'relaxed',
+                  whiteSpace: 'pre-wrap'
+                })}>
+                  {record.notes}
+                </p>
+              </div>
+            </div>
+          )}
+
+          {/* メタ情報 */}
+          <div className={css({
+            pt: '6',
+            borderTop: '1px solid',
+            borderColor: 'gray.200'
+          })}>
+            <div className={css({
+              display: 'flex',
+              alignItems: 'center',
+              gap: '6',
+              fontSize: 'sm',
+              color: 'gray.500'
+            })}>
+              <div className={css({
+                display: 'flex',
+                alignItems: 'center',
+                gap: '2'
+              })}>
+                <span>📅</span>
+                <span>作成日: {formatDate(record.createdAt)}</span>
+              </div>
+              {record.updatedAt.getTime() !== record.createdAt.getTime() && (
+                <div className={css({
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '2'
+                })}>
+                  <span>✏️</span>
+                  <span>更新日: {formatDate(record.updatedAt)}</span>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+} 

--- a/app/studyList/[id]/page.tsx
+++ b/app/studyList/[id]/page.tsx
@@ -145,16 +145,25 @@ export default function StudyRecordDetailPage() {
   };
 
   const getSubjectColor = (subject: string) => {
-    const colors = {
-      '数学': { bg: 'primary.100', text: 'accent.math' },
-      '英語': { bg: 'primary.100', text: 'accent.english' },
-      '国語': { bg: 'red.100', text: 'red.700' },
-      '理科': { bg: 'primary.100', text: 'accent.science' },
-      '社会': { bg: 'primary.100', text: 'accent.social' },
-      'プログラミング': { bg: 'primary.100', text: 'accent.programming' },
-    };
+    // 科目名からハッシュ値を生成して色を決定
+    const hash = subject.split('').reduce((acc, char) => {
+      return char.charCodeAt(0) + ((acc << 5) - acc);
+    }, 0);
     
-    return colors[subject as keyof typeof colors] || { bg: 'primary.100', text: 'accent.other' };
+    // ハッシュ値から色のインデックスを決定
+    const colorIndex = Math.abs(hash) % 6;
+    
+    // 色のパレット（6色）
+    const colorPalette = [
+      { bg: 'blue.100', text: 'blue.700' },
+      { bg: 'green.100', text: 'green.700' },
+      { bg: 'purple.100', text: 'purple.700' },
+      { bg: 'orange.100', text: 'orange.700' },
+      { bg: 'pink.100', text: 'pink.700' },
+      { bg: 'teal.100', text: 'teal.700' }
+    ];
+    
+    return colorPalette[colorIndex];
   };
 
   // 投稿者の表示名を取得
@@ -507,8 +516,8 @@ export default function StudyRecordDetailPage() {
                 })}>
                   {getAuthorAvatarUrl() ? (
                     <img
-                      src={getAuthorAvatarUrl()}
-                      alt="投稿者アバター"
+                      src={getAuthorAvatarUrl() || ''}
+                      alt="投稿者アバター" 
                       className={css({
                         w: 'full',
                         h: 'full',

--- a/app/studyList/page.tsx
+++ b/app/studyList/page.tsx
@@ -121,7 +121,7 @@ export default function StudyListPage() {
         <div className={css({
           display: 'flex',
           alignItems: 'center',
-          gap: '2'
+          gap: '4'
         })}>
           <span className={css({
             fontSize: 'sm',
@@ -129,6 +129,26 @@ export default function StudyListPage() {
           })}>
             最新順
           </span>
+          <button
+            onClick={() => router.push('/post')}
+            className={css({
+              px: '4',
+              py: '2',
+              bg: '#90EE90', // 薄緑色
+              color: 'white',
+              rounded: 'md',
+              fontSize: 'sm',
+              fontWeight: 'medium',
+              border: 'none',
+              cursor: 'pointer',
+              transition: 'all 0.2s',
+              _hover: {
+                bg: '#7FDD7F' // 少し濃い薄緑色
+              }
+            })}
+          >
+            📝 新規投稿
+          </button>
         </div>
       </div>
       <StudyRecordList records={records} loading={recordsLoading} error={error} onDelete={deleteRecord} />

--- a/app/styles/components.ts
+++ b/app/styles/components.ts
@@ -128,8 +128,8 @@ export const formStyles = {
     transition: 'all 0.2s',
     _focus: {
       outline: 'none',
-      borderColor: 'primary.500',
-      shadow: '0 0 0 3px rgba(123, 185, 130, 0.1)'
+      borderColor: 'primary.600',
+      shadow: '0 0 0 3px rgba(127, 181, 130, 0.1)'
     },
     _placeholder: {
       color: 'gray.400'
@@ -140,7 +140,7 @@ export const formStyles = {
     display: 'block',
     fontSize: 'sm',
     fontWeight: 'bold',
-    color: 'primary.800',
+    color: 'primary.700',
     mb: '2'
   }),
 
@@ -156,8 +156,8 @@ export const formStyles = {
     transition: 'all 0.2s',
     _focus: {
       outline: 'none',
-      borderColor: 'primary.500',
-      shadow: '0 0 0 3px rgba(123, 185, 130, 0.1)'
+      borderColor: 'primary.600',
+      shadow: '0 0 0 3px rgba(127, 181, 130, 0.1)'
     },
     _placeholder: {
       color: 'gray.400'


### PR DESCRIPTION
# 学習記録詳細・編集機能の実装

## 概要
学習記録の詳細表示機能と編集機能を追加し、ユーザーエクスペリエンスを向上させました。

## 主な変更内容

### �� 新機能追加

#### 1. 学習記録詳細ページ
- **ファイル**: `app/studyList/[id]/page.tsx`
- **機能**: 
  - 学習記録一覧から詳細ページへの遷移機能
  - 投稿者のカスタムユーザー名とアイコン表示（`user_profiles`テーブルから取得）
  - 編集・削除ボタンの表示（自分の投稿のみ）
  - 学習記録の詳細情報表示

#### 2. 学習記録編集ページ
- **ファイル**: `app/studyList/[id]/edit/page.tsx`
- **機能**:
  - 詳細ページの編集ボタンから遷移
  - 自分の学習記録のみ編集可能
  - 科目、学習時間、学習内容の編集機能
  - バリデーションとエラーハンドリング

### 🎨 UI/UX改善

#### 1. 学習記録カードの改善
- **ファイル**: `app/components/StudyRecordCard.tsx`
- **変更内容**:
  - カード全体をクリック可能に変更
  - 削除ボタンをLinkの外に配置（クリックイベント干渉を防止）
  - 投稿者表示を`user_profiles`テーブルの情報を優先
  - 科目名の色指定を動的生成に変更

#### 2. 科目名の色指定システム改善
- **対象ファイル**: 
  - `app/components/StudyRecordCard.tsx`
  - `app/studyList/[id]/page.tsx`
- **変更内容**:
  - 限定された科目名から任意の科目名に対応
  - ハッシュベースの色決定アルゴリズムを実装
  - 一貫性のある色表示を保証

#### 3. 新規投稿ボタンの色変更
- **ファイル**: `app/studyList/page.tsx`
- **変更内容**: 白色から薄緑色に変更

### �� 技術的改善

#### 1. データ取得の最適化
- **ファイル**: `app/hooks/useStudyRecords.ts`
- **変更内容**: 投稿者情報の取得ロジックを改善

## 変更ファイル一覧
