### PR TITLE
Develop todo

### DIFF
--- a/app/components/MobileHeader.tsx
+++ b/app/components/MobileHeader.tsx
@@ -127,9 +127,6 @@ export default function MobileHeader() {
           <Image src="/logo.svg" alt="ロゴ" width={32} height={32} className={css({ w: "8", h: "8" })} priority />
           <span className={css({ fontSize: "xl", fontWeight: "extrabold", color: "#3D8D7A", letterSpacing: "wide", textShadow: "0 1px 4px rgba(61,141,122,0.10)" })}>ちょい勉アシスト</span>
         </Link>
-        <Link href="/todoList" className={css({ color: isActive("/todoList") ? "primary.700" : "gray.700", fontWeight: "bold", fontSize: "md", _hover: { color: "primary.600" } })}>
-          TODOリスト
-        </Link>
         {user && (
           <Link href="/myPage" className={css({
             w: "8",
@@ -185,6 +182,7 @@ export default function MobileHeader() {
             <Link href="/studyList" onClick={() => setOpen(false)} className={css({ mb: "4", color: isActive("/studyList") ? "primary.700" : "primary.900", fontSize: "lg", borderBottom: isActive("/studyList") ? "2px solid #3D8D7A" : "none", pb: "1", transition: "all 0.2s", _hover: { color: "primary.600" } })}>学習記録一覧</Link>
             <Link href="/post" onClick={() => setOpen(false)} className={css({ mb: "4", color: isActive("/post") ? "primary.700" : "primary.900", fontSize: "lg", borderBottom: isActive("/post") ? "2px solid #3D8D7A" : "none", pb: "1", transition: "all 0.2s", _hover: { color: "primary.600" } })}>新規投稿</Link>
             <Link href="/studyGraph" onClick={() => setOpen(false)} className={css({ mb: "4", color: isActive("/studyGraph") ? "primary.700" : "primary.900", fontSize: "lg", borderBottom: isActive("/studyGraph") ? "2px solid #3D8D7A" : "none", pb: "1", transition: "all 0.2s", _hover: { color: "primary.600" } })}>学習グラフ</Link>
+            <Link href="/todoList" onClick={() => setOpen(false)} className={css({ mb: "4", color: isActive("/todoList") ? "primary.700" : "primary.900", fontSize: "lg", borderBottom: isActive("/todoList") ? "2px solid #3D8D7A" : "none", pb: "1", transition: "all 0.2s", _hover: { color: "primary.600" } })}>TODOリスト</Link>
             {user && (
               <div className={css({ borderTop: "1px solid", borderColor: "gray.200", pt: "4", mt: "4", display: "flex", flexDirection: "column", gap: "4" })}>
                 <Link href="/myPage" onClick={() => setOpen(false)} className={css({ color: "blue.600", fontSize: "lg", transition: "all 0.2s", _hover: { color: "blue.700" } })}>マイページ</Link>

--- a/app/components/MobileHeader.tsx
+++ b/app/components/MobileHeader.tsx
@@ -127,6 +127,9 @@ export default function MobileHeader() {
           <Image src="/logo.svg" alt="ロゴ" width={32} height={32} className={css({ w: "8", h: "8" })} priority />
           <span className={css({ fontSize: "xl", fontWeight: "extrabold", color: "#3D8D7A", letterSpacing: "wide", textShadow: "0 1px 4px rgba(61,141,122,0.10)" })}>ちょい勉アシスト</span>
         </Link>
+        <Link href="/todoList" className={css({ color: isActive("/todoList") ? "primary.700" : "gray.700", fontWeight: "bold", fontSize: "md", _hover: { color: "primary.600" } })}>
+          TODOリスト
+        </Link>
         {user && (
           <Link href="/myPage" className={css({
             w: "8",

--- a/app/components/PcHeader.tsx
+++ b/app/components/PcHeader.tsx
@@ -189,6 +189,15 @@ export default function PcHeader() {
               transition: "all 0.2s"
             }}>学習グラフ</Link>
           </li>
+          <li style={{ display: "inline-block" }}>
+            <Link href="/todoList" style={{ 
+              color: isActive("/todoList") ? "#1d4ed8" : "#1e3a8a", 
+              borderBottom: isActive("/todoList") ? "2px solid #3D8D7A" : "none", 
+              paddingBottom: "4px", 
+              textDecoration: "none",
+              transition: "all 0.2s"
+            }}>TODOリスト</Link>
+          </li>
         </ul>
         {user && (
           <div style={{ marginLeft: "auto", display: "flex", alignItems: "center", gap: "16px" }}>

--- a/app/hooks/useTodos.ts
+++ b/app/hooks/useTodos.ts
@@ -1,0 +1,114 @@
+import { useState, useEffect } from 'react';
+import { TodoItem, CreateTodoItem } from '../types/todo-item';
+import { supabase } from '../../lib/supabase';
+import { useAuth } from './useAuth';
+
+export function useTodos() {
+  const [todos, setTodos] = useState<TodoItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const { user } = useAuth();
+
+  // 一覧取得
+  const fetchTodos = async () => {
+    if (!user) {
+      setTodos([]);
+      setLoading(false);
+      return;
+    }
+    if (!supabase) {
+      setError('Supabaseが設定されていません');
+      setLoading(false);
+      return;
+    }
+    try {
+      setLoading(true);
+      setError(null);
+      const { data, error } = await supabase
+        .from('todo_items')
+        .select('*')
+        .eq('user_id', user.id)
+        .order('created_at', { ascending: false });
+      if (error) {
+        setTodos([]);
+        setError(error.message);
+        return;
+      }
+      setTodos(data || []);
+    } catch (err) {
+      setError('TODOの取得に失敗しました');
+      setTodos([]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // 追加
+  const addTodo = async (newTodo: CreateTodoItem) => {
+    if (!user) throw new Error('ユーザーが認証されていません');
+    if (!supabase) throw new Error('Supabaseが設定されていません');
+    try {
+      setError(null);
+      const { data, error } = await supabase
+        .from('todo_items')
+        .insert([{ user_id: user.id, ...newTodo }])
+        .select()
+        .single();
+      if (error) throw error;
+      setTodos(prev => [data, ...prev]);
+    } catch (err) {
+      setError('TODOの追加に失敗しました');
+      throw err;
+    }
+  };
+
+  // 削除
+  const deleteTodo = async (id: string) => {
+    if (!supabase) throw new Error('Supabaseが設定されていません');
+    try {
+      setError(null);
+      const { error } = await supabase
+        .from('todo_items')
+        .delete()
+        .eq('id', id);
+      if (error) throw error;
+      setTodos(prev => prev.filter(todo => todo.id !== id));
+    } catch (err) {
+      setError('TODOの削除に失敗しました');
+      throw err;
+    }
+  };
+
+  // ステータス変更
+  const updateStatus = async (id: string, status: 'pending' | 'completed') => {
+    if (!supabase) throw new Error('Supabaseが設定されていません');
+    try {
+      setError(null);
+      const { data, error } = await supabase
+        .from('todo_items')
+        .update({ status })
+        .eq('id', id)
+        .select()
+        .single();
+      if (error) throw error;
+      setTodos(prev => prev.map(todo => todo.id === id ? data : todo));
+    } catch (err) {
+      setError('TODOの更新に失敗しました');
+      throw err;
+    }
+  };
+
+  useEffect(() => {
+    fetchTodos();
+  }, [user]);
+
+  return {
+    todos,
+    loading,
+    error,
+    addTodo,
+    deleteTodo,
+    updateStatus,
+    refetch: fetchTodos
+  };
+} 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -71,7 +71,7 @@ export default function RootLayout({ children }: RootLayoutProps) {
               fontSize: "sm",
               color: "gray.600"
             })}>
-              © 2024 ちょい勉アシスト. 学習の記録で成長を加速させよう。
+              © 2025 ちょい勉アシスト. 学習の記録で成長を加速させよう。
             </p>
           </div>
         </footer>

--- a/app/studyGraph/page.tsx
+++ b/app/studyGraph/page.tsx
@@ -157,7 +157,7 @@ export default function StudyGraphPage() {
         </div>
         <div className={css({ flex: 1, minH: "12rem", minWidth: { base: "600px", md: "1000px" } })}>
           {data.length > 0 ? (
-            <ResponsiveContainer width={data.length * 60} height={320}>
+            <ResponsiveContainer width="100%" height={320}>
               <BarChart data={data} margin={{ top: 10, right: 20, left: 0, bottom: 10 }}>
                 <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
                 <XAxis dataKey="date" tickFormatter={formatXAxis} minTickGap={10} />

--- a/app/todoList/[id]/edit/page.tsx
+++ b/app/todoList/[id]/edit/page.tsx
@@ -1,0 +1,140 @@
+"use client";
+import { useEffect, useState } from "react";
+import { useRouter, useParams } from "next/navigation";
+import { css } from "../../../../styled-system/css";
+import { supabase } from "../../../../lib/supabase";
+import LoadingSpinner from "../../../components/ui/LoadingSpinner";
+import { TodoItem } from "../../../types/todo-item";
+
+export default function TodoEditPage() {
+  const router = useRouter();
+  const params = useParams();
+  const todoId = params.id as string;
+  const [todo, setTodo] = useState<TodoItem | null>(null);
+  const [task, setTask] = useState("");
+  const [dueDate, setDueDate] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    if (!todoId) return;
+    const fetchTodo = async () => {
+      setLoading(true);
+      setError("");
+      try {
+        const response = await supabase?.from("todo_items")
+          .select("*")
+          .eq("id", todoId)
+          .single();
+        if (response?.error) {
+          setError("TODOが見つかりません");
+          setTodo(null);
+        } else if (response?.data) {
+          setTodo(response.data);
+          setTask(response.data.task);
+          setDueDate(response.data.due_date || "");
+        }
+      } catch (err) {
+        setError("TODOの取得に失敗しました");
+        setTodo(null);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchTodo();
+  }, [todoId]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!task.trim()) {
+      setError("タスク内容を入力してください");
+      return;
+    }
+    setSaving(true);
+    setError("");
+    try {
+      const response = await supabase?.from("todo_items")
+        .update({ task: task.trim(), due_date: dueDate || null })
+        .eq("id", todoId)
+        .single();
+      if (response?.error) throw response.error;
+      router.push(`/todoList/${todoId}`);
+    } catch (err) {
+      setError("TODOの更新に失敗しました");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return <LoadingSpinner text="TODOを取得中..." />;
+  }
+  if (error || !todo) {
+    return <div className={css({ color: "red.500", textAlign: "center", py: "12" })}>{error || "TODOが見つかりません"}</div>;
+  }
+
+  return (
+    <main className={css({ maxW: "md", mx: "auto", px: "4", py: "8" })}>
+      <h2 className={css({ fontSize: "2xl", fontWeight: "bold", color: "primary.700", mb: "8" })}>TODO編集</h2>
+      <form onSubmit={handleSubmit} className={css({ display: "flex", flexDirection: "column", gap: "6" })}>
+        <div>
+          <label className={css({ fontWeight: "bold", color: "gray.700", mb: "2", display: "block" })}>タスク内容 *</label>
+          <input
+            type="text"
+            value={task}
+            onChange={e => setTask(e.target.value)}
+            className={css({
+              w: "full",
+              px: "4",
+              py: "3",
+              border: "1px solid",
+              borderColor: "gray.300",
+              rounded: "lg",
+              fontSize: "md",
+              _focus: { outline: "none", ring: "2px", ringColor: "primary.400", borderColor: "primary.400" }
+            })}
+            placeholder="例: レポート提出、買い物、勉強..."
+            required
+          />
+        </div>
+        <div>
+          <label className={css({ fontWeight: "bold", color: "gray.700", mb: "2", display: "block" })}>期限</label>
+          <input
+            type="date"
+            value={dueDate}
+            onChange={e => setDueDate(e.target.value)}
+            className={css({
+              w: "full",
+              px: "4",
+              py: "3",
+              border: "1px solid",
+              borderColor: "gray.300",
+              rounded: "lg",
+              fontSize: "md",
+              _focus: { outline: "none", ring: "2px", ringColor: "primary.400", borderColor: "primary.400" }
+            })}
+          />
+        </div>
+        {error && <div className={css({ color: "red.500", fontSize: "sm" })}>{error}</div>}
+        <button
+          type="submit"
+          className={css({
+            px: "6",
+            py: "3",
+            bg: "primary.600",
+            color: "white",
+            rounded: "md",
+            fontWeight: "bold",
+            fontSize: "md",
+            _hover: { bg: "primary.700" },
+            transition: "all 0.2s"
+          })}
+          disabled={saving}
+        >
+          {saving ? "保存中..." : "保存"}
+        </button>
+      </form>
+    </main>
+  );
+} 

--- a/app/todoList/[id]/page.tsx
+++ b/app/todoList/[id]/page.tsx
@@ -1,0 +1,87 @@
+"use client";
+import { useEffect, useState } from "react";
+import { useRouter, useParams } from "next/navigation";
+import { css } from "../../../styled-system/css";
+import { supabase } from "../../../lib/supabase";
+import LoadingSpinner from "../../components/ui/LoadingSpinner";
+import { TodoItem } from "../../types/todo-item";
+
+export default function TodoDetailPage() {
+  const router = useRouter();
+  const params = useParams();
+  const todoId = params.id as string;
+  const [todo, setTodo] = useState<TodoItem | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    if (!todoId) return;
+    const fetchTodo = async () => {
+      setLoading(true);
+      setError("");
+      try {
+        const { data, error } = await supabase
+          .from("todo_items")
+          .select("*")
+          .eq("id", todoId)
+          .single();
+        if (error) {
+          setError("TODOが見つかりません");
+          setTodo(null);
+        } else {
+          setTodo(data);
+        }
+      } catch (err) {
+        setError("TODOの取得に失敗しました");
+        setTodo(null);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchTodo();
+  }, [todoId]);
+
+  if (loading) {
+    return <LoadingSpinner text="TODOを取得中..." />;
+  }
+  if (error || !todo) {
+    return <div className={css({ color: "red.500", textAlign: "center", py: "12" })}>{error || "TODOが見つかりません"}</div>;
+  }
+
+  return (
+    <main className={css({ maxW: "md", mx: "auto", px: "4", py: "8" })}>
+      <h2 className={css({ fontSize: "2xl", fontWeight: "bold", color: "primary.700", mb: "8" })}>TODO詳細</h2>
+      <div className={css({
+        bg: "white",
+        border: "1px solid",
+        borderColor: "gray.200",
+        rounded: "xl",
+        p: "6",
+        shadow: "md",
+        mb: "8"
+      })}>
+        <div className={css({ fontWeight: "bold", fontSize: "xl", color: "primary.800", mb: "2" })}>{todo.task}</div>
+        <div className={css({ fontSize: "sm", color: "gray.600", mb: "2" })}>ステータス: {todo.status === "completed" ? "完了" : "未完了"}</div>
+        {todo.due_date && <div className={css({ fontSize: "sm", color: "gray.500", mb: "2" })}>期限: {todo.due_date}</div>}
+        <div className={css({ fontSize: "xs", color: "gray.400", mb: "2" })}>作成日: {todo.created_at.slice(0, 10)}</div>
+        <div className={css({ fontSize: "xs", color: "gray.400" })}>更新日: {todo.updated_at.slice(0, 10)}</div>
+      </div>
+      <button
+        className={css({
+          px: "6",
+          py: "3",
+          bg: "primary.600",
+          color: "white",
+          rounded: "md",
+          fontWeight: "bold",
+          fontSize: "md",
+          _hover: { bg: "primary.700" },
+          transition: "all 0.2s"
+        })}
+        onClick={() => router.push("/todoList")}
+      >
+        ← TODOリストに戻る
+      </button>
+    </main>
+  );
+} 

--- a/app/todoList/page.tsx
+++ b/app/todoList/page.tsx
@@ -1,0 +1,127 @@
+"use client";
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { css } from "../../styled-system/css";
+import { useTodos } from "../hooks/useTodos";
+import LoadingSpinner from "../components/ui/LoadingSpinner";
+import { useState } from "react";
+import Link from "next/link";
+
+export default function TodoListPage() {
+  const router = useRouter();
+  const { todos, loading, error, deleteTodo, updateStatus, refetch } = useTodos();
+  const [removingId, setRemovingId] = useState<string | null>(null);
+
+  return (
+    <main className={css({ maxW: "2xl", mx: "auto", px: "4", py: "8" })}>
+      <div className={css({ display: "flex", justifyContent: "space-between", alignItems: "center", mb: "8" })}>
+        <h2 className={css({ fontSize: "2xl", fontWeight: "bold", color: "primary.700" })}>TODOリスト</h2>
+        <button
+          className={css({
+            px: "4",
+            py: "2",
+            bg: "primary.600",
+            color: "white",
+            rounded: "md",
+            fontWeight: "bold",
+            fontSize: "sm",
+            _hover: { bg: "primary.700" },
+            transition: "all 0.2s"
+          })}
+          onClick={() => router.push("/todoPost")}
+        >
+          TODO作成
+        </button>
+      </div>
+      {loading ? (
+        <LoadingSpinner text="TODOを読み込み中..." />
+      ) : error ? (
+        <div className={css({ color: "red.500", mb: "4" })}>{error}</div>
+      ) : todos.length === 0 ? (
+        <div className={css({ color: "gray.500", textAlign: "center", py: "12" })}>TODOはありません</div>
+      ) : (
+        <ul className={css({ spaceY: "4" })}>
+          {todos.map(todo => (
+            <li
+              key={todo.id}
+              className={css({
+                p: "4",
+                bg: todo.status === "completed" ? "green.50" : "white",
+                border: "1px solid",
+                borderColor: todo.status === "completed" ? "green.200" : "gray.200",
+                rounded: "lg",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+                gap: "4",
+                transition: "background 0.2s, transform 0.5s cubic-bezier(.68,-0.55,.27,1.55), opacity 0.5s",
+                willChange: "transform, opacity",
+                cursor: "pointer",
+                ...(removingId === todo.id
+                  ? {
+                      transform: "scale(1.2) translateY(-40px)",
+                      opacity: 0,
+                      filter: "blur(2px)",
+                    }
+                  : {})
+              })}
+            >
+              <Link href={`/todoList/${todo.id}`} className={css({ flex: 1, textDecoration: "none", color: "inherit", display: "block" })}>
+                <div>
+                  <div className={css({ fontWeight: "bold", color: todo.status === "completed" ? "green.700" : "gray.900", fontSize: "lg" })}>{todo.task}</div>
+                  {todo.due_date && (
+                    <div className={css({ fontSize: "sm", color: "gray.500", mt: "1" })}>期限: {todo.due_date}</div>
+                  )}
+                  <div className={css({ fontSize: "xs", color: "gray.400", mt: "1" })}>作成日: {todo.created_at.slice(0, 10)}</div>
+                </div>
+              </Link>
+              <div className={css({ display: "flex", flexDirection: "column", gap: "2", alignItems: "flex-end" })}>
+                <button
+                  className={css({
+                    px: "3",
+                    py: "1",
+                    bg: todo.status === "completed" ? "gray.300" : "primary.500",
+                    color: todo.status === "completed" ? "gray.600" : "white",
+                    rounded: "md",
+                    fontSize: "xs",
+                    fontWeight: "bold",
+                    mb: "1",
+                    _hover: { bg: todo.status === "completed" ? "gray.400" : "primary.600" },
+                    transition: "all 0.2s"
+                  })}
+                  onClick={async () => {
+                    if (todo.status === "completed") return;
+                    setRemovingId(todo.id);
+                    setTimeout(async () => {
+                      await updateStatus(todo.id, "completed");
+                      await deleteTodo(todo.id);
+                      setRemovingId(null);
+                    }, 500);
+                  }}
+                >
+                  {todo.status === "completed" ? "完了" : "完了(泡で消す)"}
+                </button>
+                <button
+                  className={css({
+                    px: "3",
+                    py: "1",
+                    bg: "red.400",
+                    color: "white",
+                    rounded: "md",
+                    fontSize: "xs",
+                    fontWeight: "bold",
+                    _hover: { bg: "red.500" },
+                    transition: "all 0.2s"
+                  })}
+                  onClick={() => deleteTodo(todo.id)}
+                >
+                  削除
+                </button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </main>
+  );
+} 

--- a/app/todoList/page.tsx
+++ b/app/todoList/page.tsx
@@ -105,17 +105,17 @@ export default function TodoListPage() {
                   className={css({
                     px: "3",
                     py: "1",
-                    bg: "red.400",
+                    bg: "yellow.400",
                     color: "white",
                     rounded: "md",
                     fontSize: "xs",
                     fontWeight: "bold",
-                    _hover: { bg: "red.500" },
+                    _hover: { bg: "yellow.500" },
                     transition: "all 0.2s"
                   })}
-                  onClick={() => deleteTodo(todo.id)}
+                  onClick={() => router.push(`/todoList/${todo.id}/edit`)}
                 >
-                  削除
+                  編集
                 </button>
               </div>
             </li>

--- a/app/todoPost/page.tsx
+++ b/app/todoPost/page.tsx
@@ -1,0 +1,96 @@
+"use client";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { css } from "../../styled-system/css";
+import { useTodos } from "../hooks/useTodos";
+
+export default function TodoPostPage() {
+  const router = useRouter();
+  const { addTodo } = useTodos();
+  const [task, setTask] = useState("");
+  const [dueDate, setDueDate] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!task.trim()) {
+      setError("タスク内容を入力してください");
+      return;
+    }
+    setLoading(true);
+    setError("");
+    try {
+      await addTodo({ task: task.trim(), due_date: dueDate || undefined });
+      router.push("/todoList");
+    } catch (err) {
+      setError("TODOの作成に失敗しました");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <main className={css({ maxW: "md", mx: "auto", px: "4", py: "8" })}>
+      <h2 className={css({ fontSize: "2xl", fontWeight: "bold", color: "primary.700", mb: "8" })}>TODO作成</h2>
+      <form onSubmit={handleSubmit} className={css({ display: "flex", flexDirection: "column", gap: "6" })}>
+        <div>
+          <label className={css({ fontWeight: "bold", color: "gray.700", mb: "2", display: "block" })}>タスク内容 *</label>
+          <input
+            type="text"
+            value={task}
+            onChange={e => setTask(e.target.value)}
+            className={css({
+              w: "full",
+              px: "4",
+              py: "3",
+              border: "1px solid",
+              borderColor: "gray.300",
+              rounded: "lg",
+              fontSize: "md",
+              _focus: { outline: "none", ring: "2px", ringColor: "primary.400", borderColor: "primary.400" }
+            })}
+            placeholder="例: レポート提出、買い物、勉強..."
+            required
+          />
+        </div>
+        <div>
+          <label className={css({ fontWeight: "bold", color: "gray.700", mb: "2", display: "block" })}>期限</label>
+          <input
+            type="date"
+            value={dueDate}
+            onChange={e => setDueDate(e.target.value)}
+            className={css({
+              w: "full",
+              px: "4",
+              py: "3",
+              border: "1px solid",
+              borderColor: "gray.300",
+              rounded: "lg",
+              fontSize: "md",
+              _focus: { outline: "none", ring: "2px", ringColor: "primary.400", borderColor: "primary.400" }
+            })}
+          />
+        </div>
+        {error && <div className={css({ color: "red.500", fontSize: "sm" })}>{error}</div>}
+        <button
+          type="submit"
+          className={css({
+            px: "6",
+            py: "3",
+            bg: "primary.600",
+            color: "white",
+            rounded: "md",
+            fontWeight: "bold",
+            fontSize: "md",
+            _hover: { bg: "primary.700" },
+            transition: "all 0.2s"
+          })}
+          disabled={loading}
+        >
+          {loading ? "作成中..." : "作成"}
+        </button>
+      </form>
+    </main>
+  );
+} 

--- a/app/types/todo-item.ts
+++ b/app/types/todo-item.ts
@@ -1,0 +1,15 @@
+export interface TodoItem {
+  id: string;
+  user_id: string;
+  task: string;
+  due_date?: string; // ISO形式の日付文字列
+  status: 'pending' | 'completed';
+  created_at: string; // ISO形式
+  updated_at: string; // ISO形式
+}
+
+export interface CreateTodoItem {
+  task: string;
+  due_date?: string;
+  status?: 'pending' | 'completed';
+} 


### PR DESCRIPTION
概要

Supabaseのtodo_itemsテーブルに対応した、ユーザーごとのTODO管理機能を新規実装しました。
TODOリスト表示・作成・完了（泡アニメーションで削除）・詳細ページ遷移など、PandaCSSでUIを統一。
主な変更点

型・フック

app/types/todo-item.ts
todo_itemsテーブル用の型定義（TodoItem, CreateTodoItem）を新規作成
app/hooks/useTodos.ts
ユーザーごとのTODO一覧取得・追加・削除・状態変更ができるカスタムフックを新規作成
ページ・UI

app/todoList/page.tsx
TODO一覧ページを新規作成
各TODOのクリックで詳細ページへ遷移
「TODO作成」ボタンで/todoPostへ遷移
完了ボタンで泡のようなアニメーション後に自動削除
app/todoPost/page.tsx
TODO作成ページを新規作成（作成後は/todoListへリダイレクト）
app/todoList/[id]/page.tsx
TODO詳細ページを新規作成（タスク内容・期限・作成日・更新日・ステータスを表示）
ヘッダー

app/components/PcHeader.tsx
PCヘッダーに「TODOリスト（/todoList）」へのリンクを追加
app/components/MobileHeader.tsx
モバイルヘッダーに「TODOリスト（/todoList）」へのリンクを追加
補足

UIはPandaCSSで統一
完了ボタン押下時は泡のようなアニメーションで削除
RLS（行レベルセキュリティ）・認証済みユーザーのみ自身のTODOを操作可能





++++ 追加部分++++

## モバイルヘッダーにTODOリストへのリンクを追加

### 概要
- モバイル版ヘッダーメニューに「TODOリスト（/todoList）」へのリンクを追加しました。

### 変更内容
- `app/components/MobileHeader.tsx`
  - メニュー内にTODOリストへのリンクを追加し、他のメニューと同じデザイン・挙動で表示されるように修正

### 補足
- これにより、モバイル環境でもTODOリストページへ簡単にアクセスできるようになりました。

---


ご確認・ご指摘等あればコメントください！