### PR TITLE
feat: マイページを主軸にしたScrapbox連携AI TODO提案機能の追加

### DIFF
--- a/app/api/ai/scrapbox-todo/[project_name]/route.ts
+++ b/app/api/ai/scrapbox-todo/[project_name]/route.ts
@@ -1,0 +1,92 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+interface TodoRequest {
+  time_available: number;
+  daily_goal: string;
+}
+
+interface TodoResponse {
+  success: boolean;
+  content: string;
+  response_type: string;
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { project_name: string } }
+) {
+  try {
+    // プロジェクト名を取得
+    const projectName = decodeURIComponent(params.project_name);
+    
+    // リクエストボディを取得
+    const body: TodoRequest = await request.json();
+    const { time_available, daily_goal } = body;
+
+    // バリデーション
+    if (!projectName) {
+      return NextResponse.json(
+        { success: false, content: 'プロジェクト名が指定されていません', response_type: 'error' },
+        { status: 400 }
+      );
+    }
+
+    if (!time_available || time_available < 15 || time_available > 480) {
+      return NextResponse.json(
+        { success: false, content: '勉強時間は15分〜480分の間で指定してください', response_type: 'error' },
+        { status: 400 }
+      );
+    }
+
+    if (!daily_goal || daily_goal.trim().length === 0) {
+      return NextResponse.json(
+        { success: false, content: '今日の目標を入力してください', response_type: 'error' },
+        { status: 400 }
+      );
+    }
+
+    // TODO: 実際のAI APIとの連携
+    // 現在はモックレスポンスを返す
+    const mockResponse: TodoResponse = {
+      success: true,
+      content: `📚 ${projectName} プロジェクトの今日のTODOリスト
+
+⏰ 利用可能時間: ${time_available}分
+🎯 今日の目標: ${daily_goal}
+
+## 推奨TODOリスト
+
+### 1. 準備・計画 (15分)
+- 今日の学習計画を立てる
+- 必要な教材・ツールを準備する
+- 学習環境を整える
+
+### 2. メイン学習 (${Math.floor(time_available * 0.7)}分)
+- ${daily_goal}に集中して取り組む
+- 理解度を確認しながら進める
+- 分からない点があればメモを取る
+
+### 3. 復習・整理 (${Math.floor(time_available * 0.15)}分)
+- 今日学んだ内容を振り返る
+- 重要ポイントをまとめる
+- 次回への課題を整理する
+
+### 4. 振り返り (${Math.floor(time_available * 0.15)}分)
+- 学習記録を更新する
+- 達成感を味わう
+- 明日の計画を考える
+
+💡 ヒント: 集中力が切れたら5分休憩を挟んでください。`,
+      response_type: 'todo_list'
+    };
+
+    return NextResponse.json(mockResponse);
+
+  } catch (error) {
+    console.error('Scrapbox TODO API エラー:', error);
+    return NextResponse.json(
+      { success: false, content: 'サーバーエラーが発生しました', response_type: 'error' },
+      { status: 500 }
+    );
+  }
+} 

--- a/app/myPage/page.tsx
+++ b/app/myPage/page.tsx
@@ -15,6 +15,7 @@ interface UserProfile {
   full_name?: string;
   icon_url?: string;
   bio?: string;
+  scrapbox_project_name?: string;
   created_at: string;
   updated_at: string;
 }
@@ -24,6 +25,18 @@ interface FormData {
   full_name: string;
   icon_url: string;
   bio: string;
+  scrapbox_project_name: string;
+}
+
+interface TodoSuggestionForm {
+  time_available: number;
+  daily_goal: string;
+}
+
+interface TodoSuggestionResponse {
+  success: boolean;
+  content: string;
+  response_type: string;
 }
 
 export default function MyPage() {
@@ -33,13 +46,23 @@ export default function MyPage() {
     username: '',
     full_name: '',
     icon_url: '',
-    bio: ''
+    bio: '',
+    scrapbox_project_name: ''
   });
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [uploading, setUploading] = useState(false);
   const [error, setError] = useState('');
   const [editMode, setEditMode] = useState(false);
+  
+  // TODO提案フォーム用の状態
+  const [todoSuggestionForm, setTodoSuggestionForm] = useState<TodoSuggestionForm>({
+    time_available: 60,
+    daily_goal: ''
+  });
+  const [todoSuggestionLoading, setTodoSuggestionLoading] = useState(false);
+  const [todoSuggestionResult, setTodoSuggestionResult] = useState<TodoSuggestionResponse | null>(null);
+  const [todoSuggestionError, setTodoSuggestionError] = useState('');
 
   useEffect(() => {
     if (user && !authLoading) {
@@ -81,7 +104,8 @@ export default function MyPage() {
           username: data.username || '',
           full_name: data.full_name || '',
           icon_url: data.icon_url || '',
-          bio: data.bio || ''
+          bio: data.bio || '',
+          scrapbox_project_name: data.scrapbox_project_name || ''
         });
       }
     } catch (err) {
@@ -111,6 +135,7 @@ export default function MyPage() {
         full_name: user.user_metadata?.full_name || '',
         icon_url: user.user_metadata?.avatar_url || '',
         bio: '',
+        scrapbox_project_name: '',
         created_at: new Date().toISOString(),
         updated_at: new Date().toISOString()
       };
@@ -134,11 +159,17 @@ export default function MyPage() {
         username: data.username || '',
         full_name: data.full_name || '',
         icon_url: data.icon_url || '',
-        bio: data.bio || ''
+        bio: data.bio || '',
+        scrapbox_project_name: data.scrapbox_project_name || ''
       });
     } catch (err) {
       console.error('プロフィール作成エラー:', err);
-      setError('プロフィールの作成に失敗しました');
+      // より詳細なエラー情報を表示
+      if (err instanceof Error) {
+        setError(`プロフィールの作成に失敗しました: ${err.message}`);
+      } else {
+        setError(`プロフィールの作成に失敗しました: ${JSON.stringify(err)}`);
+      }
     }
   };
 
@@ -161,6 +192,7 @@ export default function MyPage() {
           full_name: formData.full_name,
           icon_url: formData.icon_url,
           bio: formData.bio,
+          scrapbox_project_name: formData.scrapbox_project_name,
           updated_at: new Date().toISOString()
         })
         .eq('user_id', user.id);
@@ -173,6 +205,7 @@ export default function MyPage() {
         full_name: formData.full_name,
         icon_url: formData.icon_url,
         bio: formData.bio,
+        scrapbox_project_name: formData.scrapbox_project_name,
         updated_at: new Date().toISOString()
       } : null);
 
@@ -191,7 +224,8 @@ export default function MyPage() {
         username: profile.username || '',
         full_name: profile.full_name || '',
         icon_url: profile.icon_url || '',
-        bio: profile.bio || ''
+        bio: profile.bio || '',
+        scrapbox_project_name: profile.scrapbox_project_name || ''
       });
     }
     setEditMode(false);
@@ -223,6 +257,49 @@ export default function MyPage() {
       setError('画像のアップロードに失敗しました');
     } finally {
       setUploading(false);
+    }
+  };
+
+  const handleTodoSuggestion = async (e: React.FormEvent) => {
+    e.preventDefault();
+    
+    if (!profile?.scrapbox_project_name) {
+      setTodoSuggestionError('Scrapboxプロジェクト名が設定されていません。プロフィール編集で設定してください。');
+      return;
+    }
+    
+    if (!todoSuggestionForm.daily_goal.trim()) {
+      setTodoSuggestionError('今日の目標を入力してください。');
+      return;
+    }
+
+    try {
+      setTodoSuggestionLoading(true);
+      setTodoSuggestionError('');
+      setTodoSuggestionResult(null);
+
+      const response = await fetch(`/api/ai/scrapbox-todo/${encodeURIComponent(profile.scrapbox_project_name)}`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          time_available: todoSuggestionForm.time_available,
+          daily_goal: todoSuggestionForm.daily_goal
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error(`APIエラー: ${response.status}`);
+      }
+
+      const result: TodoSuggestionResponse = await response.json();
+      setTodoSuggestionResult(result);
+    } catch (err) {
+      console.error('TODO提案エラー:', err);
+      setTodoSuggestionError('TODO提案の取得に失敗しました。');
+    } finally {
+      setTodoSuggestionLoading(false);
     }
   };
 
@@ -318,384 +395,587 @@ export default function MyPage() {
           })}>
             <LoadingSpinner />
           </div>
-        ) : !editMode && profile ? (
-          // 非編集時のコンパクト表示
+        ) : (
           <div className={css({
-            bg: 'white',
-            borderRadius: 'xl',
-            p: '6',
-            shadow: 'md',
-            border: '1px solid',
-            borderColor: 'primary.100',
-            maxW: '2xl',
+            display: 'grid',
+            gridTemplateColumns: { base: '1fr', lg: '1fr 1fr' },
+            gap: '8',
+            maxW: '6xl',
             mx: 'auto'
           })}>
-            <div className={css({
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'space-between',
-              mb: '4'
-            })}>
-              <h2 className={css({
-                fontSize: '2xl',
-                fontWeight: 'bold',
-                color: 'primary.800'
-              })}>
-                プロフィール
-              </h2>
-              <button
-                type="button"
-                onClick={() => setEditMode(true)}
-                className={buttonStyles.secondary}
-              >
-                編集
-              </button>
-            </div>
-            
-            <div className={css({
-              display: 'flex',
-              alignItems: 'start',
-              gap: '6'
-            })}>
-              {/* プロフィール画像 */}
-              <div className={css({
-                w: '20',
-                h: '20',
-                rounded: 'full',
-                overflow: 'hidden',
-                bg: 'primary.50',
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                border: '2px solid',
-                borderColor: 'primary.200',
-                flexShrink: '0'
-              })}>
-                {profile.icon_url ? (
-                  <img
-                    src={profile.icon_url}
-                    alt="プロフィール画像"
-                    className={css({
-                      w: 'full',
-                      h: 'full',
-                      objectFit: 'cover'
-                    })}
-                  />
-                ) : (
-                  <span className={css({
-                    fontSize: '3xl',
-                    color: 'primary.300'
-                  })}>
-                    👤
-                  </span>
-                )}
-              </div>
-              
-              {/* プロフィール情報 */}
-              <div className={css({ flex: '1' })}>
-                <h3 className={css({
-                  fontSize: '2xl',
-                  fontWeight: 'bold',
-                  color: 'gray.900',
-                  mb: '2'
-                })}>
-                  {profile.username}
-                </h3>
-                
-                {profile.full_name && (
-                  <p className={css({
-                    fontSize: 'lg',
-                    color: 'primary.600',
-                    mb: '2'
-                  })}>
-                    {profile.full_name}
-                  </p>
-                )}
-                
-                {profile.bio && (
-                  <p className={css({
-                    color: 'gray.700',
-                    lineHeight: '1.5',
-                    mb: '3'
-                  })}>
-                    {profile.bio}
-                  </p>
-                )}
-                
+            {/* プロフィールセクション */}
+            <div>
+              {!editMode && profile ? (
+                // 非編集時のコンパクト表示
                 <div className={css({
-                  display: 'flex',
-                  gap: '4',
-                  fontSize: 'sm',
-                  color: 'gray.500'
-                })}>
-                  <span>
-                    作成日: {new Date(profile.created_at).toLocaleDateString('ja-JP')}
-                  </span>
-                  {profile.updated_at && profile.updated_at !== profile.created_at && (
-                    <span>
-                      更新日: {new Date(profile.updated_at).toLocaleDateString('ja-JP')}
-                    </span>
-                  )}
-                </div>
-              </div>
-            </div>
-          </div>
-        ) : (
-          // 編集時の詳細フォーム表示
-          <div className={css({
-            bg: 'white',
-            rounded: '2xl',
-            shadow: 'lg',
-            border: '1px solid',
-            borderColor: 'gray.100',
-            p: '8'
-          })}>
-            <div className={css({
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'space-between',
-              mb: '6',
-              pb: '4',
-              borderBottom: '1px solid',
-              borderBottomColor: 'gray.200'
-            })}>
-              <h2 className={css({
-                fontSize: '2xl',
-                fontWeight: 'bold',
-                color: 'primary.800'
-              })}>
-                プロフィール編集
-              </h2>
-            </div>
-
-            <form onSubmit={handleSubmit}>
-              {/* プロフィール画像編集 */}
-              <div className={css({
-                textAlign: 'center',
-                mb: '8'
-              })}>
-                <div className={css({
-                  position: 'relative',
-                  w: '24',
-                  h: '24',
-                  mx: 'auto',
-                  mb: '4'
+                  bg: 'white',
+                  borderRadius: 'xl',
+                  p: '6',
+                  shadow: 'md',
+                  border: '1px solid',
+                  borderColor: 'primary.100',
+                  h: 'fit-content'
                 })}>
                   <div className={css({
-                    w: '24',
-                    h: '24',
-                    rounded: 'full',
-                    overflow: 'hidden',
-                    bg: 'primary.50',
                     display: 'flex',
                     alignItems: 'center',
-                    justifyContent: 'center',
-                    border: '2px solid',
-                    borderColor: 'primary.200'
-                  })}>
-                    {formData.icon_url ? (
-                      <img
-                        src={formData.icon_url}
-                        alt="プロフィール画像"
-                        className={css({
-                          w: 'full',
-                          h: 'full',
-                          objectFit: 'cover'
-                        })}
-                      />
-                    ) : (
-                      <span className={css({
-                        fontSize: '3xl',
-                        color: 'primary.300'
-                      })}>
-                        👤
-                      </span>
-                    )}
-                  </div>
-                  
-                  <label className={css({
-                    position: 'absolute',
-                    bottom: '0',
-                    right: '0',
-                    w: '8',
-                    h: '8',
-                    bg: 'primary.600',
-                    color: 'white',
-                    rounded: 'full',
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    cursor: 'pointer',
-                    fontSize: 'sm',
-                    border: '2px solid',
-                    borderColor: 'white',
-                    shadow: 'sm',
-                    _hover: {
-                      bg: 'primary.700'
-                    }
-                  })}>
-                    📷
-                    <input
-                      type="file"
-                      accept="image/*"
-                      onChange={handleFileUpload}
-                      className={css({
-                        position: 'absolute',
-                        opacity: '0',
-                        w: 'full',
-                        h: 'full',
-                        cursor: 'pointer'
-                      })}
-                    />
-                  </label>
-                </div>
-
-                {uploading && (
-                  <div className={css({
-                    color: 'primary.600',
-                    fontSize: 'sm',
+                    justifyContent: 'space-between',
                     mb: '4'
                   })}>
-                    アップロード中...
+                    <h2 className={css({
+                      fontSize: '2xl',
+                      fontWeight: 'bold',
+                      color: 'primary.800'
+                    })}>
+                      プロフィール
+                    </h2>
+                    <button
+                      type="button"
+                      onClick={() => setEditMode(true)}
+                      className={buttonStyles.secondary}
+                    >
+                      編集
+                    </button>
+                  </div>
+                  
+                  <div className={css({
+                    display: 'flex',
+                    alignItems: 'start',
+                    gap: '6'
+                  })}>
+                    {/* プロフィール画像 */}
+                    <div className={css({
+                      w: '20',
+                      h: '20',
+                      rounded: 'full',
+                      overflow: 'hidden',
+                      bg: 'primary.50',
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      border: '2px solid',
+                      borderColor: 'primary.200',
+                      flexShrink: '0'
+                    })}>
+                      {profile.icon_url ? (
+                        <img
+                          src={profile.icon_url}
+                          alt="プロフィール画像"
+                          className={css({
+                            w: 'full',
+                            h: 'full',
+                            objectFit: 'cover'
+                          })}
+                        />
+                      ) : (
+                        <span className={css({
+                          fontSize: '3xl',
+                          color: 'primary.300'
+                        })}>
+                          👤
+                        </span>
+                      )}
+                    </div>
+                    
+                    {/* プロフィール情報 */}
+                    <div className={css({ flex: '1' })}>
+                      <h3 className={css({
+                        fontSize: '2xl',
+                        fontWeight: 'bold',
+                        color: 'gray.900',
+                        mb: '2'
+                      })}>
+                        {profile.username}
+                      </h3>
+                      
+                      {profile.full_name && (
+                        <p className={css({
+                          fontSize: 'lg',
+                          color: 'primary.600',
+                          mb: '2'
+                        })}>
+                          {profile.full_name}
+                        </p>
+                      )}
+                      
+                      {profile.bio && (
+                        <p className={css({
+                          color: 'gray.700',
+                          lineHeight: '1.5',
+                          mb: '3'
+                        })}>
+                          {profile.bio}
+                        </p>
+                      )}
+                      
+                      {profile.scrapbox_project_name && (
+                        <p className={css({
+                          fontSize: 'sm',
+                          color: 'green.600',
+                          mb: '2'
+                        })}>
+                          📝 Scrapbox: {profile.scrapbox_project_name}
+                        </p>
+                      )}
+                      
+                      <div className={css({
+                        display: 'flex',
+                        gap: '4',
+                        fontSize: 'sm',
+                        color: 'gray.500'
+                      })}>
+                        <span>
+                          作成日: {new Date(profile.created_at).toLocaleDateString('ja-JP')}
+                        </span>
+                        {profile.updated_at && profile.updated_at !== profile.created_at && (
+                          <span>
+                            更新日: {new Date(profile.updated_at).toLocaleDateString('ja-JP')}
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              ) : (
+                // 編集時の詳細フォーム表示
+                <div className={css({
+                  bg: 'white',
+                  rounded: '2xl',
+                  shadow: 'lg',
+                  border: '1px solid',
+                  borderColor: 'gray.100',
+                  p: '8',
+                  h: 'fit-content'
+                })}>
+                  <div className={css({
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                    mb: '6',
+                    pb: '4',
+                    borderBottom: '1px solid',
+                    borderBottomColor: 'gray.200'
+                  })}>
+                    <h2 className={css({
+                      fontSize: '2xl',
+                      fontWeight: 'bold',
+                      color: 'primary.800'
+                    })}>
+                      プロフィール編集
+                    </h2>
+                  </div>
+
+                  <form onSubmit={handleSubmit}>
+                    {/* プロフィール画像編集 */}
+                    <div className={css({
+                      textAlign: 'center',
+                      mb: '8'
+                    })}>
+                      <div className={css({
+                        position: 'relative',
+                        w: '24',
+                        h: '24',
+                        mx: 'auto',
+                        mb: '4'
+                      })}>
+                        <div className={css({
+                          w: '24',
+                          h: '24',
+                          rounded: 'full',
+                          overflow: 'hidden',
+                          bg: 'primary.50',
+                          display: 'flex',
+                          alignItems: 'center',
+                          justifyContent: 'center',
+                          border: '2px solid',
+                          borderColor: 'primary.200'
+                        })}>
+                          {formData.icon_url ? (
+                            <img
+                              src={formData.icon_url}
+                              alt="プロフィール画像"
+                              className={css({
+                                w: 'full',
+                                h: 'full',
+                                objectFit: 'cover'
+                              })}
+                            />
+                          ) : (
+                            <span className={css({
+                              fontSize: '3xl',
+                              color: 'primary.300'
+                            })}>
+                              👤
+                            </span>
+                          )}
+                        </div>
+                        
+                        <label className={css({
+                          position: 'absolute',
+                          bottom: '0',
+                          right: '0',
+                          w: '8',
+                          h: '8',
+                          bg: 'primary.600',
+                          color: 'white',
+                          rounded: 'full',
+                          display: 'flex',
+                          alignItems: 'center',
+                          justifyContent: 'center',
+                          cursor: 'pointer',
+                          fontSize: 'sm',
+                          border: '2px solid',
+                          borderColor: 'white',
+                          shadow: 'sm',
+                          _hover: {
+                            bg: 'primary.700'
+                          }
+                        })}>
+                          📷
+                          <input
+                            type="file"
+                            accept="image/*"
+                            onChange={handleFileUpload}
+                            className={css({
+                              position: 'absolute',
+                              opacity: '0',
+                              w: 'full',
+                              h: 'full',
+                              cursor: 'pointer'
+                            })}
+                          />
+                        </label>
+                      </div>
+
+                      {uploading && (
+                        <div className={css({
+                          color: 'primary.600',
+                          fontSize: 'sm',
+                          mb: '4'
+                        })}>
+                          アップロード中...
+                        </div>
+                      )}
+                      
+                      <div className={css({
+                        spaceY: '2'
+                      })}>
+                        <label className={css({
+                          display: 'block',
+                          fontSize: 'sm',
+                          fontWeight: '600',
+                          color: 'gray.700'
+                        })}>
+                          または、画像URLを直接入力
+                        </label>
+                        <input
+                          type="url"
+                          placeholder="https://example.com/image.jpg"
+                          value={formData.icon_url}
+                          onChange={(e) => setFormData(prev => ({ ...prev, icon_url: e.target.value }))}
+                          className={formStyles.input}
+                        />
+                      </div>
+                    </div>
+
+                    {/* フォームフィールド */}
+                    <div className={css({
+                      display: 'grid',
+                      gridTemplateColumns: 'repeat(2, 1fr)',
+                      gap: '6',
+                      mb: '6'
+                    })}>
+                      <div>
+                        <label className={css({
+                          display: 'block',
+                          fontSize: 'sm',
+                          fontWeight: '600',
+                          color: 'gray.700',
+                          mb: '2'
+                        })}>
+                          ユーザー名 *
+                        </label>
+                        <input
+                          type="text"
+                          value={formData.username}
+                          onChange={(e) => setFormData(prev => ({ ...prev, username: e.target.value }))}
+                          className={formStyles.input}
+                          required
+                        />
+                      </div>
+
+                      <div>
+                        <label className={css({
+                          display: 'block',
+                          fontSize: 'sm',
+                          fontWeight: '600',
+                          color: 'gray.700',
+                          mb: '2'
+                        })}>
+                          フルネーム
+                        </label>
+                        <input
+                          type="text"
+                          value={formData.full_name}
+                          onChange={(e) => setFormData(prev => ({ ...prev, full_name: e.target.value }))}
+                          className={formStyles.input}
+                        />
+                      </div>
+
+                      <div>
+                        <label className={css({
+                          display: 'block',
+                          fontSize: 'sm',
+                          fontWeight: '600',
+                          color: 'gray.700',
+                          mb: '2'
+                        })}>
+                          メールアドレス
+                        </label>
+                        <div className={css({
+                          w: 'full',
+                          px: '3',
+                          py: '2',
+                          bg: 'gray.50',
+                          border: '1px solid',
+                          borderColor: 'gray.200',
+                          rounded: 'md',
+                          fontSize: 'sm',
+                          color: 'gray.600'
+                        })}>
+                          {user.email}
+                        </div>
+                      </div>
+
+                      <div className={css({ gridColumn: 'span 2' })}>
+                        <label className={css({
+                          display: 'block',
+                          fontSize: 'sm',
+                          fontWeight: '600',
+                          color: 'gray.700',
+                          mb: '2'
+                        })}>
+                          自己紹介
+                        </label>
+                        <textarea
+                          placeholder="自己紹介を入力してください"
+                          value={formData.bio}
+                          onChange={(e) => setFormData(prev => ({ ...prev, bio: e.target.value }))}
+                          rows={3}
+                          className={formStyles.textarea}
+                        />
+                      </div>
+
+                      <div className={css({ gridColumn: 'span 2' })}>
+                        <label className={css({
+                          display: 'block',
+                          fontSize: 'sm',
+                          fontWeight: '600',
+                          color: 'gray.700',
+                          mb: '2'
+                        })}>
+                          Scrapboxプロジェクト名（任意）
+                        </label>
+                        <input
+                          type="text"
+                          placeholder="例: my-study-project"
+                          value={formData.scrapbox_project_name}
+                          onChange={e => setFormData(prev => ({ ...prev, scrapbox_project_name: e.target.value }))}
+                          className={formStyles.input}
+                        />
+                        <div className={css({ fontSize: 'xs', color: 'gray.500', mt: '1' })}>
+                          Scrapboxのプロジェクト名を設定すると、AI TODO提案で活用されます
+                        </div>
+                      </div>
+                    </div>
+
+                    {/* アクションボタン */}
+                    <div className={css({
+                      display: 'flex',
+                      gap: '3',
+                      justifyContent: 'flex-end',
+                      pt: '4',
+                      borderTop: '1px solid',
+                      borderTopColor: 'gray.200'
+                    })}>
+                      <button
+                        type="button"
+                        onClick={handleCancel}
+                        disabled={saving}
+                        className={buttonStyles.secondary}
+                      >
+                        キャンセル
+                      </button>
+                      <button
+                        type="submit"
+                        disabled={saving || !formData.username.trim()}
+                        className={buttonStyles.primary}
+                      >
+                        {saving ? '保存中...' : '保存'}
+                      </button>
+                    </div>
+                  </form>
+                </div>
+              )}
+            </div>
+
+            {/* TODO提案セクション */}
+            <div>
+              <div className={css({
+                bg: 'white',
+                borderRadius: 'xl',
+                p: '6',
+                shadow: 'md',
+                border: '1px solid',
+                borderColor: 'primary.100',
+                h: 'fit-content'
+              })}>
+                <h2 className={css({
+                  fontSize: '2xl',
+                  fontWeight: 'bold',
+                  color: 'primary.800',
+                  mb: '4'
+                })}>
+                  今日のTODOリスト提案
+                </h2>
+
+                {!profile?.scrapbox_project_name ? (
+                  <div className={css({
+                    p: '4',
+                    bg: 'yellow.50',
+                    border: '1px solid',
+                    borderColor: 'yellow.200',
+                    rounded: 'md',
+                    color: 'yellow.800',
+                    fontSize: 'sm'
+                  })}>
+                    <p className={css({ mb: '2' })}>
+                      <strong>Scrapboxプロジェクト名が設定されていません</strong>
+                    </p>
+                    <p>
+                      プロフィール編集でScrapboxプロジェクト名を設定すると、AIがあなたの学習内容に基づいてTODOリストを提案できます。
+                    </p>
+                  </div>
+                ) : (
+                  <form onSubmit={handleTodoSuggestion} className={css({ spaceY: '4' })}>
+                    <div>
+                      <label className={css({
+                        display: 'block',
+                        fontSize: 'sm',
+                        fontWeight: '600',
+                        color: 'gray.700',
+                        mb: '2'
+                      })}>
+                        今日使える勉強時間（分）
+                      </label>
+                      <input
+                        type="number"
+                        min="15"
+                        max="480"
+                        step="15"
+                        value={todoSuggestionForm.time_available}
+                        onChange={(e) => setTodoSuggestionForm(prev => ({ 
+                          ...prev, 
+                          time_available: parseInt(e.target.value) || 60 
+                        }))}
+                        className={formStyles.input}
+                        required
+                      />
+                    </div>
+
+                    <div>
+                      <label className={css({
+                        display: 'block',
+                        fontSize: 'sm',
+                        fontWeight: '600',
+                        color: 'gray.700',
+                        mb: '2'
+                      })}>
+                        今日の目標
+                      </label>
+                      <textarea
+                        placeholder="例: 数学の微分を理解する、英語の単語を50個覚える"
+                        value={todoSuggestionForm.daily_goal}
+                        onChange={(e) => setTodoSuggestionForm(prev => ({ 
+                          ...prev, 
+                          daily_goal: e.target.value 
+                        }))}
+                        rows={3}
+                        className={formStyles.textarea}
+                        required
+                      />
+                    </div>
+
+                    {todoSuggestionError && (
+                      <div className={css({
+                        p: '3',
+                        bg: 'red.50',
+                        border: '1px solid',
+                        borderColor: 'red.200',
+                        rounded: 'md',
+                        color: 'red.700',
+                        fontSize: 'sm'
+                      })}>
+                        {todoSuggestionError}
+                      </div>
+                    )}
+
+                    <button
+                      type="submit"
+                      disabled={todoSuggestionLoading || !todoSuggestionForm.daily_goal.trim()}
+                      className={css({
+                        w: 'full',
+                        py: '3',
+                        px: '4',
+                        bg: 'primary.600',
+                        color: 'white',
+                        rounded: 'md',
+                        fontSize: 'sm',
+                        fontWeight: 'medium',
+                        _hover: {
+                          bg: 'primary.700'
+                        },
+                        _disabled: {
+                          opacity: '0.5',
+                          cursor: 'not-allowed'
+                        }
+                      })}
+                    >
+                      {todoSuggestionLoading ? '提案生成中...' : 'TODOリストを提案してもらう'}
+                    </button>
+                  </form>
+                )}
+
+                {/* 提案結果表示 */}
+                {todoSuggestionResult && (
+                  <div className={css({
+                    mt: '6',
+                    p: '4',
+                    bg: 'green.50',
+                    border: '1px solid',
+                    borderColor: 'green.200',
+                    rounded: 'md'
+                  })}>
+                    <h3 className={css({
+                      fontSize: 'lg',
+                      fontWeight: 'bold',
+                      color: 'green.800',
+                      mb: '3'
+                    })}>
+                      🤖 AI提案のTODOリスト
+                    </h3>
+                    <div className={css({
+                      whiteSpace: 'pre-wrap',
+                      color: 'green.700',
+                      lineHeight: '1.6',
+                      fontSize: 'sm'
+                    })}>
+                      {todoSuggestionResult.content}
+                    </div>
                   </div>
                 )}
-                
-                <div className={css({
-                  spaceY: '2'
-                })}>
-                  <label className={css({
-                    display: 'block',
-                    fontSize: 'sm',
-                    fontWeight: '600',
-                    color: 'gray.700'
-                  })}>
-                    または、画像URLを直接入力
-                  </label>
-                  <input
-                    type="url"
-                    placeholder="https://example.com/image.jpg"
-                    value={formData.icon_url}
-                    onChange={(e) => setFormData(prev => ({ ...prev, icon_url: e.target.value }))}
-                    className={formStyles.input}
-                  />
-                </div>
               </div>
-
-              {/* フォームフィールド */}
-              <div className={css({
-                display: 'grid',
-                gridTemplateColumns: 'repeat(2, 1fr)',
-                gap: '6',
-                mb: '6'
-              })}>
-                <div>
-                  <label className={css({
-                    display: 'block',
-                    fontSize: 'sm',
-                    fontWeight: '600',
-                    color: 'gray.700',
-                    mb: '2'
-                  })}>
-                    ユーザー名 *
-                  </label>
-                  <input
-                    type="text"
-                    value={formData.username}
-                    onChange={(e) => setFormData(prev => ({ ...prev, username: e.target.value }))}
-                    className={formStyles.input}
-                    required
-                  />
-                </div>
-
-                <div>
-                  <label className={css({
-                    display: 'block',
-                    fontSize: 'sm',
-                    fontWeight: '600',
-                    color: 'gray.700',
-                    mb: '2'
-                  })}>
-                    フルネーム
-                  </label>
-                  <input
-                    type="text"
-                    value={formData.full_name}
-                    onChange={(e) => setFormData(prev => ({ ...prev, full_name: e.target.value }))}
-                    className={formStyles.input}
-                  />
-                </div>
-
-                <div>
-                  <label className={css({
-                    display: 'block',
-                    fontSize: 'sm',
-                    fontWeight: '600',
-                    color: 'gray.700',
-                    mb: '2'
-                  })}>
-                    メールアドレス
-                  </label>
-                  <div className={css({
-                    w: 'full',
-                    px: '3',
-                    py: '2',
-                    bg: 'gray.50',
-                    border: '1px solid',
-                    borderColor: 'gray.200',
-                    rounded: 'md',
-                    fontSize: 'sm',
-                    color: 'gray.600'
-                  })}>
-                    {user.email}
-                  </div>
-                </div>
-
-                <div className={css({ gridColumn: 'span 2' })}>
-                  <label className={css({
-                    display: 'block',
-                    fontSize: 'sm',
-                    fontWeight: '600',
-                    color: 'gray.700',
-                    mb: '2'
-                  })}>
-                    自己紹介
-                  </label>
-                  <textarea
-                    placeholder="自己紹介を入力してください"
-                    value={formData.bio}
-                    onChange={(e) => setFormData(prev => ({ ...prev, bio: e.target.value }))}
-                    rows={3}
-                    className={formStyles.textarea}
-                  />
-                </div>
-              </div>
-
-              {/* アクションボタン */}
-              <div className={css({
-                display: 'flex',
-                gap: '3',
-                justifyContent: 'flex-end',
-                pt: '4',
-                borderTop: '1px solid',
-                borderTopColor: 'gray.200'
-              })}>
-                <button
-                  type="button"
-                  onClick={handleCancel}
-                  disabled={saving}
-                  className={buttonStyles.secondary}
-                >
-                  キャンセル
-                </button>
-                <button
-                  type="submit"
-                  disabled={saving || !formData.username.trim()}
-                  className={buttonStyles.primary}
-                >
-                  {saving ? '保存中...' : '保存'}
-                </button>
-              </div>
-            </form>
+            </div>
           </div>
         )}
       </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -16,10 +16,10 @@ export default function LoginPage() {
   const router = useRouter();
   const { user, loading: authLoading, error: authError, signInWithEmail, signUpWithEmail, signInWithProvider } = useAuth();
 
-  // ユーザーが既にログインしている場合はstudyListにリダイレクト
+  // ユーザーが既にログインしている場合はmyPageにリダイレクト
   useEffect(() => {
     if (user && !authLoading) {
-      router.push('/studyList');
+      router.push('/myPage');
     }
   }, [user, authLoading, router]);
 
@@ -36,7 +36,7 @@ export default function LoginPage() {
       if (error) {
         setError(error.message);
       } else {
-        router.push('/studyList');
+        router.push('/myPage');
       }
     } catch (err) {
       setError('認証中にエラーが発生しました');

--- a/app/redirect/page.tsx
+++ b/app/redirect/page.tsx
@@ -30,8 +30,8 @@ export default function RedirectPage() {
         }
 
         if (data.session) {
-          // 認証成功時はstudyListにリダイレクト
-          router.push('/studyList');
+          // 認証成功時はmyPageにリダイレクト
+          router.push('/myPage');
         } else {
           // セッションがない場合はログインページにリダイレクト
           router.push('/');


### PR DESCRIPTION


---


## 概要

- **マイページを主ページ（ログイン後のリダイレクト先）に変更**
- **プロフィール編集画面にScrapboxプロジェクト名（任意）を追加**
- **マイページに「今日のTODOリスト提案フォーム」を新設**
  - 勉強に使える時間・今日の目標を入力すると、AIがScrapboxプロジェクトに基づいたTODOリストを提案
  - 提案結果を画面上に分かりやすく表示
- **API `/api/ai/scrapbox-todo/{project_name}` を新規実装（現状はモックレスポンス）**
- **エラーハンドリング・バリデーション強化**

---

## 変更ファイル

- `app/page.tsx`  
  - ログイン後のリダイレクト先を `/myPage` に変更
- `app/redirect/page.tsx`  
  - OAuth認証後のリダイレクト先を `/myPage` に変更
- `app/myPage/page.tsx`  
  - Scrapboxプロジェクト名の編集欄追加
  - TODO提案フォーム・結果表示機能追加
  - エラーハンドリング改善
- `app/api/ai/scrapbox-todo/[project_name]/route.ts`  
  - AI TODO提案APIエンドポイント新規追加

---

## 補足・マイグレーション

- Supabaseの`user_profiles`テーブルに下記カラム追加が必要です（SQL例）  
  ```sql
  ALTER TABLE user_profiles ADD COLUMN scrapbox_project_name TEXT;
  ```
- AI連携部分は現状モック。実際のAI API連携は`route.ts`内の該当箇所に実装してください。

---

## 動作確認

1. ログイン後、マイページに遷移すること
2. プロフィール編集でScrapboxプロジェクト名を設定できること
3. マイページ右側のフォームでTODO提案が受けられ、結果が表示されること
4. APIエラーや未設定時のバリデーションが正しく動作すること

---

