### PR TITLE
Develop todo

### DIFF
--- a/app/components/MobileHeader.tsx
+++ b/app/components/MobileHeader.tsx
@@ -51,15 +51,7 @@ export default function MobileHeader() {
 
   // アバターURLを取得する関数
   const getAvatarUrl = () => {
-    // 1. カスタムアバター（user_profiles.icon_url）を優先
-    if (profile?.icon_url) {
-      return profile.icon_url;
-    }
-    // 2. OAuthアバター（user_metadata.avatar_url）をフォールバック
-    if (user?.user_metadata?.avatar_url) {
-      return user.user_metadata.avatar_url;
-    }
-    return null;
+    return profile?.icon_url || undefined;
   };
 
   // アバターの初期文字を取得する関数

--- a/app/components/PcHeader.tsx
+++ b/app/components/PcHeader.tsx
@@ -52,15 +52,7 @@ export default function PcHeader() {
 
   // アバターURLを取得する関数
   const getAvatarUrl = () => {
-    // 1. カスタムアバター（user_profiles.icon_url）を優先
-    if (profile?.icon_url) {
-      return profile.icon_url;
-    }
-    // 2. OAuthアバター（user_metadata.avatar_url）をフォールバック
-    if (user?.user_metadata?.avatar_url) {
-      return user.user_metadata.avatar_url;
-    }
-    return null;
+    return profile?.icon_url || undefined;
   };
 
   // 表示名を取得する関数

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -105,10 +105,11 @@ export default function LoginPage() {
           spaceY: '4'
         })}>
           <div>
-            <label className={formStyles.label}>
+            <label htmlFor="email" className={formStyles.label}>
               メールアドレス
             </label>
             <input
+              id="email"
               type="email"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
@@ -118,10 +119,11 @@ export default function LoginPage() {
           </div>
 
           <div>
-            <label className={formStyles.label}>
+            <label htmlFor="password" className={formStyles.label}>
               パスワード
             </label>
             <input
+              id="password"
               type="password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}


### PR DESCRIPTION
## 概要

- Googleログイン時でも「アプリ独自のアイコン（user_profiles.icon_url）」のみを表示・保存するように修正
- Googleアカウントのアイコン（user_metadata.avatar_url）は一切使用しない仕様に統一
- プロフィール新規作成・編集時もGoogleアイコンで上書きされることがないように修正
- ログイン・サインアップ画面の細かな修正

---

## 変更内容

### フロントエンド

- **app/components/PcHeader.tsx, MobileHeader.tsx**
  - getAvatarUrl関数を修正し、user_profiles.icon_urlのみを参照
  - Googleアカウントのアイコンは一切表示しない

- **app/myPage/page.tsx**
  - プロフィール新規作成時（createProfile）もGoogleアイコンで上書きせず、アプリ独自のアイコンのみ保存・表示
  - プロフィール編集・保存時も同様

- **app/page.tsx**
  - ログイン・サインアップ画面のUI/UX微修正

---

## 動作確認

- Googleログイン時でも、プロフィール編集画面で設定した独自アイコンのみが表示されることを確認
- Googleアカウントのアイコンが一切表示されないことを確認
- プロフィール画像のアップロード・URL入力・保存が正常に反映されることを確認
- ログイン・サインアップ画面の動作確認

---

## 補足

- 既存のGoogleアカウントのアイコンで上書きされる現象は完全に解消されています
- 追加の要望や不具合があればご指摘ください
