### PR TITLE
fix: 環境変数名をBACKEND_API_URLに修正

### DIFF
--- a/app/api/ai/scrapbox-todo/[project_name]/route.ts
+++ b/app/api/ai/scrapbox-todo/[project_name]/route.ts
@@ -28,7 +28,7 @@ export async function POST(
     }
 
     // バックエンドAPIにリクエストを送信
-    const backendUrl = process.env.BACKEND_URL;
+    const backendUrl = process.env.BACKEND_API_URL;
     const backendRes = await fetch(`${backendUrl}/api/ai/scrapbox-todo/${encodeURIComponent(projectName)}`, {
       method: 'POST',
       headers: {

--- a/app/api/ai/todo/route.ts
+++ b/app/api/ai/todo/route.ts
@@ -23,7 +23,7 @@ export async function POST(request: NextRequest) {
     }
 
     // バックエンドAPIにリクエストを送信
-    const backendUrl = process.env.BACKEND_URL;
+    const backendUrl = process.env.BACKEND_API_URL;
     const backendRes = await fetch(`${backendUrl}/api/ai/todo`, {
       method: 'POST',
       headers: {


### PR DESCRIPTION
## 変更内容

環境変数名を正しく`BACKEND_API_URL`に修正しました：

### 更新されたファイル：
1. `app/api/ai/scrapbox-todo/[project_name]/route.ts`
2. `app/api/ai/todo/route.ts`

### 現在の設定：
```typescript
const backendUrl = process.env.BACKEND_API_URL;
```
