### PR TITLE
fix: 環境変数をBACKEND_API_URLに変更し、API呼び出しを修正

### DIFF
--- a/app/actions/todo-actions.ts
+++ b/app/actions/todo-actions.ts
@@ -2,11 +2,14 @@
 
 export async function generateTodo(projectName: string, timeAvailable: number, dailyGoal?: string) {
   try {
-    const response = await fetch(`https://choiben-back.youkan.uk/api/ai/scrapbox-todo/${projectName}`, {
+    if (!process.env.BACKEND_API_URL) {
+      throw new Error('BACKEND_API_URLが設定されていません');
+    }
+
+    const response = await fetch(`${process.env.BACKEND_API_URL}/api/ai/scrapbox-todo/${projectName}`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': `Bearer ${process.env.API_SECRET_KEY}`,
       },
       body: JSON.stringify({
         time_available: timeAvailable,
@@ -15,6 +18,7 @@ export async function generateTodo(projectName: string, timeAvailable: number, d
     });
 
     if (!response.ok) {
+      console.error(`API呼び出しエラー: ${response.status} ${response.statusText}`);
       throw new Error(`HTTP error! status: ${response.status}`);
     }
 
@@ -32,11 +36,14 @@ export async function generateTodo(projectName: string, timeAvailable: number, d
 
 export async function generateGeneralTodo(timeAvailable: number, recentProgress?: string, weakAreas?: string[], dailyGoal?: string) {
   try {
-    const response = await fetch(`https://choiben-back.youkan.uk/api/ai/todo`, {
+    if (!process.env.BACKEND_API_URL) {
+      throw new Error('BACKEND_API_URLが設定されていません');
+    }
+
+    const response = await fetch(`${process.env.BACKEND_API_URL}/api/ai/todo`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': `Bearer ${process.env.API_SECRET_KEY}`,
       },
       body: JSON.stringify({
         time_available: timeAvailable,
@@ -47,6 +54,7 @@ export async function generateGeneralTodo(timeAvailable: number, recentProgress?
     });
 
     if (!response.ok) {
+      console.error(`API呼び出しエラー: ${response.status} ${response.statusText}`);
       throw new Error(`HTTP error! status: ${response.status}`);
     }
 

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -104,6 +104,7 @@ export default function LoginPage() {
               onChange={(e) => setEmail(e.target.value)}
               placeholder="メールアドレス"
               required
+              autoComplete="email"
               className={css({
                 w: 'full',
                 px: '3',
@@ -129,6 +130,7 @@ export default function LoginPage() {
               onChange={(e) => setPassword(e.target.value)}
               placeholder="パスワード"
               required
+              autoComplete="current-password"
               className={css({
                 w: 'full',
                 px: '3',


### PR DESCRIPTION
## Pull Request: Scrapbox連携機能の復活とAI API連携の実装

### �� 概要
マイページでのScrapbox連携機能を復活させ、実際のバックエンドAI APIとの連携を実装しました。また、ビルドエラーの修正とセキュリティ向上も行いました。

### ✨ 主な変更点

#### 1. **Scrapbox連携機能の復活**
- プロフィール編集でScrapboxプロジェクト名を設定可能
- Scrapbox連携モード/詳細入力モードの切り替えUI
- プロジェクト固有のTODO生成機能

#### 2. **AI API連携の実装**
- `generateTodo`: Scrapbox連携API（`/api/ai/scrapbox-todo/[project_name]`）
- `generateGeneralTodo`: 一般AI提案API（`/api/ai/todo`）
- 環境変数 `BACKEND_API_URL` を使用したAPI呼び出し
- エラーハンドリングの改善

#### 3. **型安全性の確保**
- `TodoSuggestionResponse`型に統一
- 型エラーの解消

#### 4. **ビルドエラーの修正**
- ESLintエラーの修正（インポート順序、trailing spaces）
- ビルド安定性の向上

#### 5. **セキュリティ向上**
- ログインフォームに `autocomplete` 属性を追加
- パスワードマネージャーとの連携改善

### �� 技術的な変更

#### 修正されたファイル
- `app/actions/todo-actions.ts` - AI API連携の実装
- `app/myPage/page.tsx` - Scrapbox連携UIの復活
- `app/page.tsx` - ダッシュボードでのAI API呼び出し
- `app/login/page.tsx` - autocomplete属性の追加
- `app/studyGraph/page.tsx` - study_records削除対応

#### 環境変数
- `BACKEND_API_URL`: バックエンドAPIのベースURL

### �� テスト項目
- [ ] マイページでScrapboxプロジェクト名の設定
- [ ] Scrapbox連携モードでのTODO生成
- [ ] 詳細入力モードでのTODO生成
- [ ] ダッシュボードでのAI提案機能
- [ ] ログインフォームのautocomplete動作
- [ ] ビルドの成功確認

### 🚀 デプロイ要件
Vercelで以下の環境変数を設定してください：
```
BACKEND_API_URL=https://your-backend-api-url.com
```
