### PR TITLE
fix: AI提案TODOのチェックボックス機能を修正 - セクション自動展開、クリックイベント競合解消

### DIFF
--- a/app/components/AiTodoSuggestion.tsx
+++ b/app/components/AiTodoSuggestion.tsx
@@ -20,6 +20,23 @@ export default function AiTodoSuggestion({ content, onAddTodos }: AiTodoSuggesti
   const sections = parseMarkdownTodos(content);
   const allTodos = flattenTodoSections(sections);
 
+  // デバッグ情報
+  console.warn('🔍 AI提案デバッグ:', {
+    contentLength: content.length,
+    sectionsCount: sections.length,
+    allTodosCount: allTodos.length,
+    sections: sections.map(s => ({ title: s.title, todosCount: s.todos.length })),
+    selectedSections,
+    selectedTodos
+  });
+
+  // 初期化時にすべてのセクションを展開
+  React.useEffect(() => {
+    if (sections.length > 0 && selectedSections.length === 0) {
+      setSelectedSections(sections.map(section => section.title));
+    }
+  }, [sections, selectedSections.length]);
+
   // セクション選択の切り替え
   const toggleSection = (sectionTitle: string) => {
     setSelectedSections(prev => {
@@ -253,11 +270,16 @@ export default function AiTodoSuggestion({ content, onAddTodos }: AiTodoSuggesti
                       <input
                         type="checkbox"
                         checked={isSelected}
-                        onChange={() => toggleTodo(todoId)}
+                        onChange={(e) => {
+                          e.stopPropagation();
+                          toggleTodo(todoId);
+                        }}
+                        onClick={(e) => e.stopPropagation()}
                         className={css({
                           w: '4',
                           h: '4',
-                          accentColor: 'green.600'
+                          accentColor: 'green.600',
+                          cursor: 'pointer'
                         })}
                       />
                       <div className={css({


### PR DESCRIPTION
## **修正内容**

### **問題の原因**
1. **セクションが閉じている**: デフォルトでセクションが閉じていたため、TODOが見えなかった
2. **クリックイベントの競合**: チェックボックスとdivの両方にクリックイベントがあり、競合していた

### **修正内容**

1. **セクションの自動展開**
   ```typescript
   // 初期化時にすべてのセクションを展開
   React.useEffect(() => {
     if (sections.length > 0 && selectedSections.length === 0) {
       setSelectedSections(sections.map(section => section.title));
     }
   }, [sections, selectedSections.length]);
   ```

2. **クリックイベントの競合解消**
   ```typescript
   <input
     type="checkbox"
     checked={isSelected}
     onChange={(e) => {
       e.stopPropagation(); // イベントの伝播を停止
       toggleTodo(todoId);
     }}
     onClick={(e) => e.stopPropagation()} // クリックイベントも停止
     className={css({
       w: '4',
       h: '4',
       accentColor: 'green.600',
       cursor: 'pointer'
     })}
   />
   ```

3. **デバッグ情報の追加**
   ```typescript
   console.warn('�� AI提案デバッグ:', {
     contentLength: content.length,
     sectionsCount: sections.length,
     allTodosCount: allTodos.length,
     sections: sections.map(s => ({ title: s.title, todosCount: s.todos.length })),
     selectedSections,
     selectedTodos
   });
   ```

### **期待される結果**

- **TODOが表示される**: セクションが自動的に展開されるため、TODOがすぐに見える
- **チェックボックスが機能する**: クリックイベントの競合が解消され、チェックボックスが正常に動作する
- **デバッグ情報**: ブラウザのコンソールでTODOの解析状況を確認できる
