### PR TITLE
プロフィールの変更

### DIFF
--- a/app/components/ActivityHeatmap.tsx
+++ b/app/components/ActivityHeatmap.tsx
@@ -1,0 +1,329 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+import dayjs from 'dayjs';
+import { css } from '../../styled-system/css';
+import { supabase } from '../../lib/supabase';
+
+interface ActivityData {
+  date: string;
+  count: number;
+  level: 0 | 1 | 2 | 3 | 4; // GitHub草風のレベル
+}
+
+interface ActivityHeatmapProps {
+  userId: string;
+  startDate?: Date;
+  endDate?: Date;
+}
+
+export default function ActivityHeatmap({ userId, startDate, endDate }: ActivityHeatmapProps) {
+  const [activityData, setActivityData] = useState<ActivityData[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [dateRange, setDateRange] = useState<{ start: Date; end: Date } | null>(null);
+
+  const fetchActivityData = useCallback(async () => {
+    if (!supabase || !userId) return;
+
+    try {
+      setLoading(true);
+
+      // デフォルトで過去365日を表示
+      const defaultStartDate = startDate || dayjs().subtract(365, 'days').toDate();
+      const defaultEndDate = endDate || new Date();
+      
+      // 日付範囲を状態に保存
+      setDateRange({ start: defaultStartDate, end: defaultEndDate });
+
+      // TODO完了データを取得
+      const { data: todos, error } = await supabase
+        .from('todo_items')
+        .select('completed_at, created_at')
+        .eq('user_id', userId)
+        .gte('completed_at', dayjs(defaultStartDate).format('YYYY-MM-DD'))
+        .lte('completed_at', dayjs(defaultEndDate).format('YYYY-MM-DD'))
+        .not('completed_at', 'is', null);
+
+      if (error) throw error;
+
+      // 日付範囲内のすべての日付を生成
+      const dateRange: string[] = [];
+      let currentDate = dayjs(defaultStartDate);
+      while (currentDate.isBefore(dayjs(defaultEndDate)) || currentDate.isSame(dayjs(defaultEndDate), 'day')) {
+        dateRange.push(currentDate.format('YYYY-MM-DD'));
+        currentDate = currentDate.add(1, 'day');
+      }
+
+      // 日付ごとにTODO完了数を集計
+      const todoCountByDate: Record<string, number> = {};
+      todos?.forEach(todo => {
+        if (todo.completed_at) {
+          const date = dayjs(todo.completed_at).format('YYYY-MM-DD');
+          todoCountByDate[date] = (todoCountByDate[date] || 0) + 1;
+        }
+      });
+
+      // アクティビティレベルを計算（0-4の5段階）
+      const maxCount = Math.max(...Object.values(todoCountByDate), 1);
+      const activityData: ActivityData[] = dateRange.map(date => {
+        const count = todoCountByDate[date] || 0;
+        let level: 0 | 1 | 2 | 3 | 4 = 0;
+        
+        if (count > 0) {
+          const ratio = count / maxCount;
+          if (ratio >= 0.75) level = 4;
+          else if (ratio >= 0.5) level = 3;
+          else if (ratio >= 0.25) level = 2;
+          else level = 1;
+        }
+
+        return { date, count, level };
+      });
+
+      setActivityData(activityData);
+    } catch (error) {
+      console.error('Activity data fetch error:', error);
+    } finally {
+      setLoading(false);
+    }
+  }, [userId, startDate, endDate]);
+
+  useEffect(() => {
+    fetchActivityData();
+  }, [fetchActivityData]);
+
+  const getColorForLevel = (level: number): string => {
+    const colors = {
+      0: '#ebedf0', // 薄いグレー
+      1: '#9be9a8', // 薄い緑
+      2: '#40c463', // 中程度の緑
+      3: '#30a14e', // 濃い緑
+      4: '#216e39'  // 最も濃い緑
+    };
+    return colors[level as keyof typeof colors] || colors[0];
+  };
+
+  const getTooltipText = (data: ActivityData): string => {
+    const date = dayjs(data.date).format('YYYY年M月D日');
+    if (data.count === 0) {
+      return `${date}: TODO完了なし`;
+    }
+    return `${date}: ${data.count}個のTODOを完了`;
+  };
+
+  // 週ごとにデータをグループ化
+  const getWeeksData = () => {
+    const weeks: ActivityData[][] = [];
+    let currentWeek: ActivityData[] = [];
+    
+    activityData.forEach((data, index) => {
+      const dayOfWeek = dayjs(data.date).day(); // 0 = 日曜日
+      
+      if (index === 0) {
+        // 最初の週の場合、日曜日でない場合は空のセルで埋める
+        for (let i = 0; i < dayOfWeek; i++) {
+          currentWeek.push({ date: '', count: 0, level: 0 });
+        }
+      }
+      
+      currentWeek.push(data);
+      
+      if (dayOfWeek === 6 || index === activityData.length - 1) {
+        // 土曜日または最後のデータの場合、週を完成させる
+        while (currentWeek.length < 7) {
+          currentWeek.push({ date: '', count: 0, level: 0 });
+        }
+        weeks.push(currentWeek);
+        currentWeek = [];
+      }
+    });
+    
+    return weeks;
+  };
+
+  const totalContributions = activityData.reduce((sum, data) => sum + data.count, 0);
+  const streakDays = calculateStreakDays();
+
+  function calculateStreakDays(): number {
+    let streak = 0;
+    for (let i = activityData.length - 1; i >= 0; i--) {
+      if (activityData[i].count > 0) {
+        streak++;
+      } else {
+        break;
+      }
+    }
+    return streak;
+  }
+
+  if (loading) {
+    return (
+      <div className={css({
+        bg: 'white',
+        rounded: '2xl',
+        shadow: 'md',
+        p: '6',
+        border: '1px solid',
+        borderColor: 'gray.100'
+      })}>
+        <div className={css({
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          h: '40'
+        })}>
+          <div className={css({
+            w: '8',
+            h: '8',
+            border: '2px solid',
+            borderColor: 'primary.200',
+            borderTopColor: 'primary.600',
+            rounded: 'full'
+          })} style={{ animation: 'spin 1s linear infinite' }} />
+        </div>
+      </div>
+    );
+  }
+
+  const weeksData = getWeeksData();
+
+  return (
+    <div className={css({
+      bg: 'white',
+      rounded: '2xl',
+      shadow: 'md',
+      p: '6',
+      border: '1px solid',
+      borderColor: 'gray.100'
+    })}>
+      <div className={css({
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        mb: '4'
+      })}>
+        <h3 className={css({
+          fontSize: 'xl',
+          fontWeight: 'bold',
+          color: 'gray.900'
+        })}>
+          学習アクティビティ
+        </h3>
+        <div className={css({
+          display: 'flex',
+          gap: '4',
+          fontSize: 'sm',
+          color: 'gray.600'
+        })}>
+          <span>総完了: {totalContributions}個</span>
+          <span>連続: {streakDays}日</span>
+        </div>
+      </div>
+
+      {/* 月ラベル */}
+      <div className={css({
+        display: 'flex',
+        gap: '1',
+        mb: '2',
+        fontSize: 'xs',
+        color: 'gray.500',
+        justifyContent: 'space-between'
+      })}>
+        {dateRange && Array.from({ length: 12 }, (_, i) => {
+          const month = dayjs(dateRange.start).add(i, 'month');
+          return (
+            <span key={i} className={css({ minW: '8', textAlign: 'center' })}>
+              {month.format('M月')}
+            </span>
+          );
+        })}
+      </div>
+
+      {/* ヒートマップグリッド */}
+      <div className={css({
+        display: 'flex',
+        gap: '1',
+        overflowX: 'auto',
+        pb: '2'
+      })}>
+        {/* 曜日ラベル */}
+        <div className={css({
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '1',
+          mr: '2'
+        })}>
+          {['日', '月', '火', '水', '木', '金', '土'].map((day, index) => (
+            <div
+              key={index}
+              className={css({
+                w: '3',
+                h: '3',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                fontSize: 'xs',
+                color: 'gray.400'
+              })}
+            >
+              {index % 2 === 1 ? day : ''}
+            </div>
+          ))}
+        </div>
+
+        {/* 週ごとのグリッド */}
+        {weeksData.map((week, weekIndex) => (
+          <div key={weekIndex} className={css({
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '1'
+          })}>
+            {week.map((data, dayIndex) => (
+              <div
+                key={`${weekIndex}-${dayIndex}`}
+                className={css({
+                  w: '3',
+                  h: '3',
+                  rounded: 'sm',
+                  cursor: data.date ? 'pointer' : 'default',
+                  position: 'relative',
+                  _hover: data.date ? { opacity: '0.8' } : {}
+                })}
+                style={{
+                  backgroundColor: data.date ? getColorForLevel(data.level) : 'transparent'
+                }}
+                title={data.date ? getTooltipText(data) : ''}
+              />
+            ))}
+          </div>
+        ))}
+      </div>
+
+      {/* レベル説明 */}
+      <div className={css({
+        display: 'flex',
+        alignItems: 'center',
+        gap: '2',
+        mt: '4',
+        fontSize: 'xs',
+        color: 'gray.500'
+      })}>
+        <span>少ない</span>
+        <div className={css({ display: 'flex', gap: '1' })}>
+          {[0, 1, 2, 3, 4].map(level => (
+            <div
+              key={level}
+              className={css({
+                w: '2.5',
+                h: '2.5',
+                rounded: 'sm'
+              })}
+              style={{ backgroundColor: getColorForLevel(level) }}
+            />
+          ))}
+        </div>
+        <span>多い</span>
+      </div>
+    </div>
+  );
+}

--- a/app/components/ActivityHeatmap.tsx
+++ b/app/components/ActivityHeatmap.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { useEffect, useState, useCallback } from 'react';
 import dayjs from 'dayjs';
-import { css } from '../../styled-system/css';
+import { useCallback, useEffect, useState } from 'react';
+
 import { supabase } from '../../lib/supabase';
+import { css } from '../../styled-system/css';
 
 interface ActivityData {
   date: string;

--- a/app/components/ProfileCard.tsx
+++ b/app/components/ProfileCard.tsx
@@ -1,0 +1,518 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import Image from 'next/image';
+import { css } from '../../styled-system/css';
+import { supabase } from '../../lib/supabase';
+import LoadingSpinner from './ui/LoadingSpinner';
+import MarkdownRenderer from './ui/MarkdownRenderer';
+import { buttonStyles, formStyles } from '../styles/components';
+
+interface UserProfile {
+  id: string;
+  user_id: string;
+  username: string;
+  full_name?: string;
+  icon_url?: string;
+  bio?: string;
+  scrapbox_project_name?: string;
+  created_at: string;
+  updated_at: string;
+}
+
+interface FormData {
+  username: string;
+  full_name: string;
+  icon_url: string;
+  bio: string;
+  scrapbox_project_name: string;
+}
+
+interface ProfileCardProps {
+  profile: UserProfile | null;
+  user: any;
+  onProfileUpdate: (updatedProfile: UserProfile) => void;
+}
+
+export default function ProfileCard({ profile, user, onProfileUpdate }: ProfileCardProps) {
+  const [editMode, setEditMode] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [uploading, setUploading] = useState(false);
+  const [error, setError] = useState('');
+  const [formData, setFormData] = useState<FormData>({
+    username: profile?.username || '',
+    full_name: profile?.full_name || '',
+    icon_url: profile?.icon_url || '',
+    bio: profile?.bio || '',
+    scrapbox_project_name: profile?.scrapbox_project_name || ''
+  });
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!user || !formData.username.trim()) {
+      setError('ユーザー名は必須です');
+      return;
+    }
+
+    try {
+      setSaving(true);
+      setError('');
+
+      const { error } = await supabase!
+        .from('user_profiles')
+        .update({
+          username: formData.username,
+          full_name: formData.full_name,
+          icon_url: formData.icon_url,
+          bio: formData.bio,
+          scrapbox_project_name: formData.scrapbox_project_name,
+          updated_at: new Date().toISOString()
+        })
+        .eq('user_id', user.id);
+
+      if (error) throw error;
+
+      const updatedProfile = {
+        ...profile!,
+        username: formData.username,
+        full_name: formData.full_name,
+        icon_url: formData.icon_url,
+        bio: formData.bio,
+        scrapbox_project_name: formData.scrapbox_project_name,
+        updated_at: new Date().toISOString()
+      };
+
+      onProfileUpdate(updatedProfile);
+      setEditMode(false);
+    } catch (err) {
+      console.error('プロフィール更新エラー:', err);
+      setError('プロフィールの更新に失敗しました');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleCancel = () => {
+    if (profile) {
+      setFormData({
+        username: profile.username || '',
+        full_name: profile.full_name || '',
+        icon_url: profile.icon_url || '',
+        bio: profile.bio || '',
+        scrapbox_project_name: profile.scrapbox_project_name || ''
+      });
+    }
+    setEditMode(false);
+    setError('');
+  };
+
+  const handleFileUpload = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file || !user) return;
+
+    try {
+      setUploading(true);
+
+      const fileExt = file.name.split('.').pop();
+      const fileName = `${user.id}.${fileExt}`;
+      const filePath = `${user.id}/${fileName}`;
+
+      const { error: uploadError } = await supabase!.storage
+        .from('avatars')
+        .upload(filePath, file, {
+          cacheControl: '3600',
+          upsert: true,
+        });
+
+      if (uploadError) throw uploadError;
+
+      const { data: { publicUrl } } = supabase!.storage
+        .from('avatars')
+        .getPublicUrl(filePath);
+
+      setFormData(prev => ({ ...prev, icon_url: publicUrl }));
+    } catch (err) {
+      console.error('画像アップロードエラー:', err);
+      setError('画像のアップロードに失敗しました');
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  if (!profile) return null;
+
+  return (
+    <div className={css({
+      bg: 'white',
+      rounded: '2xl',
+      shadow: 'xl',
+      border: '1px solid',
+      borderColor: 'gray.100',
+      overflow: 'hidden'
+    })}>
+      {/* Header */}
+      <div className={css({
+        bg: 'gradient-to-r',
+        bgGradient: 'to-r',
+        gradientFrom: 'primary.500',
+        gradientTo: 'primary.600',
+        px: '6',
+        py: '4',
+        color: 'white'
+      })}>
+        <div className={css({
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between'
+        })}>
+          <h2 className={css({
+            fontSize: '2xl',
+            fontWeight: 'bold'
+          })}>
+            プロフィール
+          </h2>
+          {!editMode && (
+            <button
+              type="button"
+              onClick={() => setEditMode(true)}
+              className={css({
+                px: '4',
+                py: '2',
+                bg: 'white',
+                color: 'primary.600',
+                rounded: 'md',
+                fontSize: 'sm',
+                fontWeight: 'medium',
+                _hover: { bg: 'primary.50' },
+                border: 'none',
+                cursor: 'pointer'
+              })}
+            >
+              編集
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className={css({ p: '6' })}>
+        {error && (
+          <div className={css({
+            mb: '4',
+            p: '3',
+            bg: 'red.50',
+            border: '1px solid',
+            borderColor: 'red.200',
+            rounded: 'md',
+            color: 'red.700',
+            fontSize: 'sm'
+          })}>
+            {error}
+          </div>
+        )}
+
+        {!editMode ? (
+          // Display Mode
+          <div className={css({
+            display: 'flex',
+            alignItems: 'start',
+            gap: '6'
+          })}>
+            {/* Avatar */}
+            <div className={css({
+              w: '24',
+              h: '24',
+              rounded: 'full',
+              overflow: 'hidden',
+              bg: 'primary.50',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              border: '3px solid',
+              borderColor: 'primary.200',
+              flexShrink: '0'
+            })}>
+              {profile.icon_url ? (
+                <Image
+                  src={profile.icon_url}
+                  alt="プロフィール画像"
+                  width={96}
+                  height={96}
+                  className={css({
+                    w: 'full',
+                    h: 'full',
+                    objectFit: 'cover'
+                  })}
+                />
+              ) : (
+                <span className={css({
+                  fontSize: '4xl',
+                  color: 'primary.300'
+                })}>
+                  👤
+                </span>
+              )}
+            </div>
+
+            {/* Profile Info */}
+            <div className={css({ flex: '1' })}>
+              <h3 className={css({
+                fontSize: '2xl',
+                fontWeight: 'bold',
+                color: 'gray.900',
+                mb: '2'
+              })}>
+                {profile.username}
+              </h3>
+
+              {profile.full_name && (
+                <p className={css({
+                  fontSize: 'lg',
+                  color: 'primary.600',
+                  mb: '3',
+                  fontWeight: 'medium'
+                })}>
+                  {profile.full_name}
+                </p>
+              )}
+
+              {profile.bio && (
+                <div className={css({
+                  mb: '4'
+                })}>
+                  <MarkdownRenderer 
+                    content={profile.bio}
+                    className={css({
+                      color: 'gray.600',
+                      lineHeight: 'relaxed'
+                    })}
+                  />
+                </div>
+              )}
+
+              {profile.scrapbox_project_name && (
+                <div className={css({
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: '2',
+                  bg: 'green.50',
+                  color: 'green.700',
+                  px: '3',
+                  py: '1',
+                  rounded: 'full',
+                  fontSize: 'sm',
+                  fontWeight: 'medium',
+                  border: '1px solid',
+                  borderColor: 'green.200'
+                })}>
+                  📚 Scrapbox: {profile.scrapbox_project_name}
+                </div>
+              )}
+
+              <div className={css({
+                display: 'flex',
+                gap: '6',
+                fontSize: 'sm',
+                color: 'gray.500',
+                mt: '4'
+              })}>
+                <span>登録日: {new Date(profile.created_at).toLocaleDateString('ja-JP')}</span>
+                <span>更新日: {new Date(profile.updated_at).toLocaleDateString('ja-JP')}</span>
+              </div>
+            </div>
+          </div>
+        ) : (
+          // Edit Mode
+          <form onSubmit={handleSubmit}>
+            {/* Avatar Upload */}
+            <div className={css({
+              textAlign: 'center',
+              mb: '6'
+            })}>
+              <div className={css({
+                position: 'relative',
+                w: '24',
+                h: '24',
+                mx: 'auto',
+                mb: '4'
+              })}>
+                <div className={css({
+                  w: 'full',
+                  h: 'full',
+                  rounded: 'full',
+                  overflow: 'hidden',
+                  bg: 'primary.50',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  border: '3px solid',
+                  borderColor: 'primary.200'
+                })}>
+                  {formData.icon_url ? (
+                    <Image
+                      src={formData.icon_url}
+                      alt="プロフィール画像"
+                      width={96}
+                      height={96}
+                      className={css({
+                        w: 'full',
+                        h: 'full',
+                        objectFit: 'cover'
+                      })}
+                    />
+                  ) : (
+                    <span className={css({
+                      fontSize: '4xl',
+                      color: 'primary.300'
+                    })}>
+                      👤
+                    </span>
+                  )}
+                </div>
+
+                <input
+                  id="file_upload"
+                  type="file"
+                  accept="image/*"
+                  onChange={handleFileUpload}
+                  className={css({
+                    position: 'absolute',
+                    inset: '0',
+                    w: 'full',
+                    h: 'full',
+                    opacity: '0',
+                    cursor: 'pointer'
+                  })}
+                />
+              </div>
+
+              {uploading && (
+                <div className={css({ mb: '2' })}>
+                  <LoadingSpinner />
+                </div>
+              )}
+
+              <div className={css({ spaceY: '2' })}>
+                <label htmlFor="icon_url_input" className={formStyles.label}>
+                  画像URL（直接入力）
+                </label>
+                <input
+                  id="icon_url_input"
+                  type="url"
+                  placeholder="https://example.com/image.jpg"
+                  value={formData.icon_url}
+                  onChange={(e) => setFormData(prev => ({ ...prev, icon_url: e.target.value }))}
+                  className={formStyles.input}
+                />
+              </div>
+            </div>
+
+            {/* Form Fields */}
+            <div className={css({
+              display: 'grid',
+              gridTemplateColumns: 'repeat(2, 1fr)',
+              gap: '6',
+              mb: '6'
+            })}>
+              <div>
+                <label htmlFor="username_input" className={formStyles.label}>
+                  ユーザー名 <span className={css({ color: 'red.500' })}>*</span>
+                </label>
+                <input
+                  id="username_input"
+                  type="text"
+                  value={formData.username}
+                  onChange={(e) => setFormData(prev => ({ ...prev, username: e.target.value }))}
+                  className={formStyles.input}
+                  required
+                />
+              </div>
+
+              <div>
+                <label htmlFor="full_name_input" className={formStyles.label}>
+                  フルネーム
+                </label>
+                <input
+                  id="full_name_input"
+                  type="text"
+                  value={formData.full_name}
+                  onChange={(e) => setFormData(prev => ({ ...prev, full_name: e.target.value }))}
+                  className={formStyles.input}
+                />
+              </div>
+
+              <div className={css({ gridColumn: 'span 2' })}>
+                <label htmlFor="scrapbox_project_name_input" className={formStyles.label}>
+                  Scrapboxプロジェクト名
+                </label>
+                <input
+                  id="scrapbox_project_name_input"
+                  type="text"
+                  placeholder="例: my-study-project"
+                  value={formData.scrapbox_project_name}
+                  onChange={e => setFormData(prev => ({ ...prev, scrapbox_project_name: e.target.value }))}
+                  className={formStyles.input}
+                />
+                <p className={css({
+                  fontSize: 'xs',
+                  color: 'gray.500',
+                  mt: '1'
+                })}>
+                  設定するとTODO提案機能でScrapboxの情報を活用できます
+                </p>
+              </div>
+
+              <div className={css({ gridColumn: 'span 2' })}>
+                <label htmlFor="bio_input" className={formStyles.label}>
+                  自己紹介
+                </label>
+                <textarea
+                  id="bio_input"
+                  placeholder="自己紹介を入力してください&#10;&#10;**マークダウン記法**が使用できます：&#10;- **太字**、*斜体*&#10;- # 見出し&#10;- [リンク](https://example.com)&#10;- `コード`&#10;- > 引用&#10;- - リスト"
+                  value={formData.bio}
+                  onChange={(e) => setFormData(prev => ({ ...prev, bio: e.target.value }))}
+                  rows={5}
+                  className={formStyles.textarea}
+                />
+                <p className={css({
+                  fontSize: 'xs',
+                  color: 'gray.500',
+                  mt: '1'
+                })}>
+                  マークダウン記法（**太字**、*斜体*、# 見出し、リンクなど）がサポートされています
+                </p>
+              </div>
+            </div>
+
+            {/* Action Buttons */}
+            <div className={css({
+              display: 'flex',
+              gap: '3',
+              justifyContent: 'flex-end',
+              pt: '4',
+              borderTop: '1px solid',
+              borderTopColor: 'gray.200'
+            })}>
+              <button
+                type="button"
+                onClick={handleCancel}
+                disabled={saving}
+                className={buttonStyles.secondary}
+              >
+                キャンセル
+              </button>
+              <button
+                type="submit"
+                disabled={saving || !formData.username.trim()}
+                className={buttonStyles.primary}
+              >
+                {saving ? '保存中...' : '保存'}
+              </button>
+            </div>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/components/ProfileCard.tsx
+++ b/app/components/ProfileCard.tsx
@@ -1,12 +1,14 @@
 'use client';
 
-import { useState, useCallback } from 'react';
 import Image from 'next/image';
-import { css } from '../../styled-system/css';
+import React, { useState } from 'react';
+
 import { supabase } from '../../lib/supabase';
+import { css } from '../../styled-system/css';
+import { buttonStyles, formStyles } from '../styles/components';
+
 import LoadingSpinner from './ui/LoadingSpinner';
 import MarkdownRenderer from './ui/MarkdownRenderer';
-import { buttonStyles, formStyles } from '../styles/components';
 
 interface UserProfile {
   id: string;
@@ -28,10 +30,14 @@ interface FormData {
   scrapbox_project_name: string;
 }
 
+interface User {
+  id: string;
+}
+
 interface ProfileCardProps {
   profile: UserProfile | null;
-  user: any;
-  onProfileUpdate: (updatedProfile: UserProfile) => void;
+  user: User;
+  onProfileUpdate: (_updatedProfile: UserProfile) => void;
 }
 
 export default function ProfileCard({ profile, user, onProfileUpdate }: ProfileCardProps) {

--- a/app/components/RecentTodos.tsx
+++ b/app/components/RecentTodos.tsx
@@ -1,9 +1,11 @@
 'use client';
 
-import { useEffect, useState } from 'react';
 import dayjs from 'dayjs';
-import { css } from '../../styled-system/css';
+import { useCallback, useEffect, useState } from 'react';
+
 import { supabase } from '../../lib/supabase';
+import { css } from '../../styled-system/css';
+
 import LoadingSpinner from './ui/LoadingSpinner';
 
 interface CompletedTodo {
@@ -24,11 +26,7 @@ export default function RecentTodos({ userId, limit = 10 }: RecentTodosProps) {
   const [completedTodos, setCompletedTodos] = useState<CompletedTodo[]>([]);
   const [loading, setLoading] = useState(true);
 
-  useEffect(() => {
-    fetchCompletedTodos();
-  }, [userId, limit]);
-
-  const fetchCompletedTodos = async () => {
+  const fetchCompletedTodos = useCallback(async () => {
     if (!supabase || !userId) return;
 
     try {
@@ -50,7 +48,11 @@ export default function RecentTodos({ userId, limit = 10 }: RecentTodosProps) {
     } finally {
       setLoading(false);
     }
-  };
+  }, [userId, limit]);
+
+  useEffect(() => {
+    fetchCompletedTodos();
+  }, [fetchCompletedTodos]);
 
   const getPriorityColor = (priority: string) => {
     const colors = {

--- a/app/components/RecentTodos.tsx
+++ b/app/components/RecentTodos.tsx
@@ -1,0 +1,286 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import dayjs from 'dayjs';
+import { css } from '../../styled-system/css';
+import { supabase } from '../../lib/supabase';
+import LoadingSpinner from './ui/LoadingSpinner';
+
+interface CompletedTodo {
+  id: string;
+  title: string;
+  description?: string;
+  priority: string;
+  completed_at: string;
+  created_at: string;
+}
+
+interface RecentTodosProps {
+  userId: string;
+  limit?: number;
+}
+
+export default function RecentTodos({ userId, limit = 10 }: RecentTodosProps) {
+  const [completedTodos, setCompletedTodos] = useState<CompletedTodo[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetchCompletedTodos();
+  }, [userId, limit]);
+
+  const fetchCompletedTodos = async () => {
+    if (!supabase || !userId) return;
+
+    try {
+      setLoading(true);
+
+      const { data, error } = await supabase
+        .from('todo_items')
+        .select('id, title, description, priority, completed_at, created_at')
+        .eq('user_id', userId)
+        .not('completed_at', 'is', null)
+        .order('completed_at', { ascending: false })
+        .limit(limit);
+
+      if (error) throw error;
+
+      setCompletedTodos(data || []);
+    } catch (error) {
+      console.error('完了済みTODO取得エラー:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const getPriorityColor = (priority: string) => {
+    const colors = {
+      '高': 'red.500',
+      '中': 'amber.500',
+      '低': 'green.500'
+    };
+    return colors[priority as keyof typeof colors] || 'gray.500';
+  };
+
+  const getPriorityBg = (priority: string) => {
+    const colors = {
+      '高': 'red.50',
+      '中': 'amber.50',
+      '低': 'green.50'
+    };
+    return colors[priority as keyof typeof colors] || 'gray.50';
+  };
+
+  if (loading) {
+    return (
+      <div className={css({
+        bg: 'white',
+        rounded: '2xl',
+        shadow: 'md',
+        p: '6',
+        border: '1px solid',
+        borderColor: 'gray.100'
+      })}>
+        <h3 className={css({
+          fontSize: 'xl',
+          fontWeight: 'bold',
+          color: 'gray.900',
+          mb: '4'
+        })}>
+          最近完了したTODO
+        </h3>
+        <div className={css({
+          display: 'flex',
+          justifyContent: 'center',
+          py: '8'
+        })}>
+          <LoadingSpinner />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={css({
+      bg: 'white',
+      rounded: '2xl',
+      shadow: 'md',
+      p: '6',
+      border: '1px solid',
+      borderColor: 'gray.100'
+    })}>
+      <div className={css({
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        mb: '4'
+      })}>
+        <h3 className={css({
+          fontSize: 'xl',
+          fontWeight: 'bold',
+          color: 'gray.900'
+        })}>
+          最近完了したTODO
+        </h3>
+        <span className={css({
+          bg: 'primary.50',
+          color: 'primary.700',
+          px: '3',
+          py: '1',
+          rounded: 'full',
+          fontSize: 'sm',
+          fontWeight: 'medium'
+        })}>
+          {completedTodos.length}件
+        </span>
+      </div>
+
+      {completedTodos.length === 0 ? (
+        <div className={css({
+          textAlign: 'center',
+          py: '8',
+          color: 'gray.500'
+        })}>
+          <div className={css({
+            fontSize: '3xl',
+            mb: '2'
+          })}>
+            📝
+          </div>
+          <p>完了したTODOがありません</p>
+          <p className={css({
+            fontSize: 'sm',
+            mt: '1'
+          })}>
+            TODOを完了すると、ここに表示されます
+          </p>
+        </div>
+      ) : (
+        <div className={css({
+          spaceY: '3',
+          maxH: '96',
+          overflowY: 'auto'
+        })}>
+          {completedTodos.map((todo) => (
+            <div
+              key={todo.id}
+              className={css({
+                p: '4',
+                border: '1px solid',
+                borderColor: 'gray.200',
+                rounded: 'lg',
+                _hover: { borderColor: 'primary.300', shadow: 'sm' },
+                transition: 'all 0.2s'
+              })}
+            >
+              <div className={css({
+                display: 'flex',
+                alignItems: 'start',
+                justifyContent: 'space-between',
+                gap: '3'
+              })}>
+                <div className={css({ flex: '1' })}>
+                  <div className={css({
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '2',
+                    mb: '2'
+                  })}>
+                    <h4 className={css({
+                      fontWeight: 'semibold',
+                      color: 'gray.900',
+                      textDecoration: 'line-through',
+                      textDecorationColor: 'gray.400'
+                    })}>
+                      {todo.title}
+                    </h4>
+                    <span
+                      className={css({
+                        px: '2',
+                        py: '0.5',
+                        rounded: 'md',
+                        fontSize: 'xs',
+                        fontWeight: 'medium',
+                        color: getPriorityColor(todo.priority),
+                        bg: getPriorityBg(todo.priority)
+                      })}
+                    >
+                      {todo.priority}
+                    </span>
+                  </div>
+
+                  {todo.description && (
+                    <p className={css({
+                      color: 'gray.600',
+                      fontSize: 'sm',
+                      mb: '2',
+                      lineHeight: 'relaxed'
+                    })}>
+                      {todo.description}
+                    </p>
+                  )}
+
+                  <div className={css({
+                    display: 'flex',
+                    gap: '4',
+                    fontSize: 'xs',
+                    color: 'gray.500'
+                  })}>
+                    <span>
+                      完了: {dayjs(todo.completed_at).format('MM/DD HH:mm')}
+                    </span>
+                    <span>
+                      作成: {dayjs(todo.created_at).format('MM/DD')}
+                    </span>
+                  </div>
+                </div>
+
+                <div className={css({
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  w: '8',
+                  h: '8',
+                  bg: 'green.50',
+                  color: 'green.600',
+                  rounded: 'full',
+                  fontSize: 'lg',
+                  flexShrink: '0'
+                })}>
+                  ✓
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {completedTodos.length >= limit && (
+        <div className={css({
+          textAlign: 'center',
+          mt: '4',
+          pt: '4',
+          borderTop: '1px solid',
+          borderTopColor: 'gray.200'
+        })}>
+          <button
+            onClick={() => fetchCompletedTodos()}
+            className={css({
+              px: '4',
+              py: '2',
+              bg: 'primary.50',
+              color: 'primary.700',
+              rounded: 'md',
+              fontSize: 'sm',
+              fontWeight: 'medium',
+              _hover: { bg: 'primary.100' },
+              border: 'none',
+              cursor: 'pointer'
+            })}
+          >
+            もっと見る
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/components/StudyPosts.tsx
+++ b/app/components/StudyPosts.tsx
@@ -1,0 +1,356 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import dayjs from 'dayjs';
+import { css } from '../../styled-system/css';
+import { supabase } from '../../lib/supabase';
+import LoadingSpinner from './ui/LoadingSpinner';
+import MarkdownRenderer from './ui/MarkdownRenderer';
+
+interface StudyPost {
+  id: string;
+  user_id: string;
+  content: string;
+  hashtags: string[];
+  is_public: boolean;
+  todo_id: string | null;
+  created_at: string;
+  updated_at: string;
+  username: string | null;
+  full_name: string | null;
+  icon_url: string | null;
+  likes_count: number;
+  comments_count: number;
+  is_liked: boolean;
+}
+
+interface StudyPostsProps {
+  userId: string;
+  limit?: number;
+}
+
+export default function StudyPosts({ userId, limit = 5 }: StudyPostsProps) {
+  const [posts, setPosts] = useState<StudyPost[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetchStudyPosts();
+  }, [userId, limit]);
+
+  const fetchStudyPosts = async () => {
+    if (!supabase || !userId) return;
+
+    try {
+      setLoading(true);
+
+      // まずtimeline_posts_with_statsビューから投稿を取得を試行
+      let { data, error } = await supabase
+        .from('timeline_posts_with_stats')
+        .select('*')
+        .eq('user_id', userId)
+        .order('created_at', { ascending: false })
+        .limit(limit);
+
+      // timeline_postsが存在しない場合、study_recordsから取得（フォールバック）
+      if (error && error.message.includes('relation "timeline_posts_with_stats" does not exist')) {
+        console.log('タイムラインテーブルが未作成のため、study_recordsからデータを取得します');
+        
+        const fallbackResult = await supabase
+          .from('study_records')
+          .select('id, title, content, created_at, updated_at, tags')
+          .eq('user_id', userId)
+          .order('created_at', { ascending: false })
+          .limit(limit);
+
+        if (fallbackResult.error) throw fallbackResult.error;
+
+        // study_recordsデータをStudyPost形式に変換
+        const convertedData = (fallbackResult.data || []).map(record => ({
+          id: record.id,
+          user_id: userId,
+          content: record.content,
+          hashtags: record.tags || [],
+          is_public: true,
+          todo_id: null,
+          created_at: record.created_at,
+          updated_at: record.updated_at,
+          username: null,
+          full_name: null,
+          icon_url: null,
+          likes_count: 0,
+          comments_count: 0,
+          is_liked: false
+        }));
+
+        setPosts(convertedData);
+      } else if (error) {
+        throw error;
+      } else {
+        setPosts(data || []);
+      }
+    } catch (error) {
+      console.error('学習投稿取得エラー:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const truncateContent = (content: string, maxLength: number = 150) => {
+    if (content.length <= maxLength) return content;
+    return content.substring(0, maxLength) + '...';
+  };
+
+  if (loading) {
+    return (
+      <div className={css({
+        bg: 'white',
+        rounded: '2xl',
+        shadow: 'md',
+        p: '6',
+        border: '1px solid',
+        borderColor: 'gray.100'
+      })}>
+        <h3 className={css({
+          fontSize: 'xl',
+          fontWeight: 'bold',
+          color: 'gray.900',
+          mb: '4'
+        })}>
+          最近の学習投稿
+        </h3>
+        <div className={css({
+          display: 'flex',
+          justifyContent: 'center',
+          py: '8'
+        })}>
+          <LoadingSpinner />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={css({
+      bg: 'white',
+      rounded: '2xl',
+      shadow: 'md',
+      p: '6',
+      border: '1px solid',
+      borderColor: 'gray.100'
+    })}>
+      <div className={css({
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        mb: '4'
+      })}>
+        <h3 className={css({
+          fontSize: 'xl',
+          fontWeight: 'bold',
+          color: 'gray.900'
+        })}>
+          最近の学習投稿
+        </h3>
+        <span className={css({
+          bg: 'primary.50',
+          color: 'primary.700',
+          px: '3',
+          py: '1',
+          rounded: 'full',
+          fontSize: 'sm',
+          fontWeight: 'medium'
+        })}>
+          {posts.length}件
+        </span>
+      </div>
+
+      {posts.length === 0 ? (
+        <div className={css({
+          textAlign: 'center',
+          py: '8',
+          color: 'gray.500'
+        })}>
+          <div className={css({
+            fontSize: '3xl',
+            mb: '2'
+          })}>
+            📚
+          </div>
+          <p>学習投稿がありません</p>
+          <p className={css({
+            fontSize: 'sm',
+            mt: '1'
+          })}>
+            学習記録を投稿すると、ここに表示されます
+          </p>
+        </div>
+      ) : (
+        <div className={css({
+          spaceY: '4',
+          maxH: '96',
+          overflowY: 'auto'
+        })}>
+          {posts.map((post) => (
+            <article
+              key={post.id}
+              className={css({
+                p: '4',
+                border: '1px solid',
+                borderColor: 'gray.200',
+                rounded: 'lg',
+                _hover: { borderColor: 'primary.300', shadow: 'sm' },
+                transition: 'all 0.2s'
+              })}
+            >
+              <header className={css({ mb: '3' })}>
+                <div className={css({
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  gap: '2'
+                })}>
+                  <time className={css({
+                    fontSize: 'sm',
+                    color: 'gray.500'
+                  })}>
+                    {dayjs(post.created_at).format('YYYY/MM/DD HH:mm')}
+                  </time>
+                  
+                  <div className={css({
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '3'
+                  })}>
+                    {/* いいね数 */}
+                    <div className={css({
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: '1',
+                      color: post.is_liked ? 'red.500' : 'gray.500',
+                      fontSize: 'sm'
+                    })}>
+                      <span>{post.is_liked ? '❤️' : '🤍'}</span>
+                      <span>{post.likes_count}</span>
+                    </div>
+                    
+                    {/* コメント数 */}
+                    <div className={css({
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: '1',
+                      color: 'gray.500',
+                      fontSize: 'sm'
+                    })}>
+                      <span>💬</span>
+                      <span>{post.comments_count}</span>
+                    </div>
+                  </div>
+                </div>
+                
+                {post.hashtags && post.hashtags.length > 0 && (
+                  <div className={css({
+                    display: 'flex',
+                    gap: '1',
+                    flexWrap: 'wrap',
+                    mt: '2'
+                  })}>
+                    {post.hashtags.slice(0, 3).map((tag: string, index: number) => (
+                      <span
+                        key={index}
+                        className={css({
+                          px: '2',
+                          py: '0.5',
+                          bg: 'primary.50',
+                          color: 'primary.700',
+                          rounded: 'md',
+                          fontSize: 'xs',
+                          fontWeight: 'medium'
+                        })}
+                      >
+                        #{tag}
+                      </span>
+                    ))}
+                    {post.hashtags.length > 3 && (
+                      <span className={css({
+                        fontSize: 'xs',
+                        color: 'gray.500'
+                      })}>
+                        +{post.hashtags.length - 3}
+                      </span>
+                    )}
+                  </div>
+                )}
+              </header>
+
+              <div className={css({
+                color: 'gray.600',
+                fontSize: 'sm',
+                lineHeight: 'relaxed'
+              })}>
+                <MarkdownRenderer content={truncateContent(post.content)} />
+              </div>
+
+              {post.content.length > 150 && (
+                <button
+                  className={css({
+                    mt: '2',
+                    color: 'primary.600',
+                    fontSize: 'sm',
+                    fontWeight: 'medium',
+                    _hover: { color: 'primary.800' },
+                    border: 'none',
+                    bg: 'transparent',
+                    cursor: 'pointer'
+                  })}
+                >
+                  続きを読む
+                </button>
+              )}
+
+              {post.updated_at !== post.created_at && (
+                <div className={css({
+                  mt: '2',
+                  pt: '2',
+                  borderTop: '1px solid',
+                  borderTopColor: 'gray.100',
+                  fontSize: 'xs',
+                  color: 'gray.500'
+                })}>
+                  更新: {dayjs(post.updated_at).format('YYYY/MM/DD HH:mm')}
+                </div>
+              )}
+            </article>
+          ))}
+        </div>
+      )}
+
+      {posts.length >= limit && (
+        <div className={css({
+          textAlign: 'center',
+          mt: '4',
+          pt: '4',
+          borderTop: '1px solid',
+          borderTopColor: 'gray.200'
+        })}>
+          <button
+            onClick={() => fetchStudyPosts()}
+            className={css({
+              px: '4',
+              py: '2',
+              bg: 'primary.50',
+              color: 'primary.700',
+              rounded: 'md',
+              fontSize: 'sm',
+              fontWeight: 'medium',
+              _hover: { bg: 'primary.100' },
+              border: 'none',
+              cursor: 'pointer'
+            })}
+          >
+            もっと見る
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/components/ui/MarkdownRenderer.tsx
+++ b/app/components/ui/MarkdownRenderer.tsx
@@ -2,6 +2,7 @@
 
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+
 import { css } from '../../../styled-system/css';
 
 interface MarkdownRendererProps {

--- a/app/components/ui/MarkdownRenderer.tsx
+++ b/app/components/ui/MarkdownRenderer.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { css } from '../../../styled-system/css';
+
+interface MarkdownRendererProps {
+  content: string;
+  className?: string;
+}
+
+export default function MarkdownRenderer({ content, className }: MarkdownRendererProps) {
+  const markdownStyles = css({
+    '& p': {
+      mb: '2',
+      lineHeight: 'relaxed'
+    },
+    '& h1, & h2, & h3, & h4, & h5, & h6': {
+      fontWeight: 'bold',
+      mb: '2',
+      mt: '4',
+      _first: { mt: '0' }
+    },
+    '& h1': { fontSize: 'xl' },
+    '& h2': { fontSize: 'lg' },
+    '& h3': { fontSize: 'md' },
+    '& ul, & ol': {
+      pl: '4',
+      mb: '2'
+    },
+    '& li': {
+      mb: '1'
+    },
+    '& code': {
+      bg: 'gray.100',
+      px: '1',
+      py: '0.5',
+      rounded: 'sm',
+      fontSize: 'sm',
+      fontFamily: 'mono'
+    },
+    '& pre': {
+      bg: 'gray.100',
+      p: '3',
+      rounded: 'md',
+      overflow: 'auto',
+      mb: '3'
+    },
+    '& pre code': {
+      bg: 'transparent',
+      p: '0'
+    },
+    '& blockquote': {
+      borderLeft: '4px solid',
+      borderLeftColor: 'gray.300',
+      pl: '4',
+      py: '2',
+      bg: 'gray.50',
+      mb: '3',
+      fontStyle: 'italic'
+    },
+    '& a': {
+      color: 'primary.600',
+      textDecoration: 'underline',
+      _hover: { color: 'primary.700' }
+    },
+    '& strong': {
+      fontWeight: 'bold'
+    },
+    '& em': {
+      fontStyle: 'italic'
+    },
+    '& hr': {
+      border: 'none',
+      borderTop: '1px solid',
+      borderTopColor: 'gray.200',
+      my: '4'
+    },
+    '& table': {
+      w: 'full',
+      borderCollapse: 'collapse',
+      mb: '3'
+    },
+    '& th, & td': {
+      border: '1px solid',
+      borderColor: 'gray.200',
+      px: '3',
+      py: '2',
+      textAlign: 'left'
+    },
+    '& th': {
+      bg: 'gray.50',
+      fontWeight: 'bold'
+    }
+  });
+
+  return (
+    <div className={`${markdownStyles} ${className || ''}`}>
+      <ReactMarkdown remarkPlugins={[remarkGfm]}>
+        {content}
+      </ReactMarkdown>
+    </div>
+  );
+}

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,18 +1,14 @@
 'use client';
 
-import Image from 'next/image';
-import React, { useState, useEffect, useCallback } from 'react';
-
-import { supabase } from '../../lib/supabase';
+import { useState, useCallback, useEffect } from 'react';
 import { css } from '../../styled-system/css';
-import { generateTodo, generateGeneralTodo } from '../actions/todo-actions';
-import AiTodoSuggestion from '../components/AiTodoSuggestion';
-import ErrorMessage from '../components/ui/ErrorMessage';
-import LoadingSpinner from '../components/ui/LoadingSpinner';
 import { useAuth } from '../hooks/useAuth';
-import { useTodos } from '../hooks/useTodos';
-import { buttonStyles, formStyles } from '../styles/components';
-import { CreateTodoItem } from '../types/todo-item';
+import { supabase } from '../../lib/supabase';
+import ProfileCard from '../components/ProfileCard';
+import ActivityHeatmap from '../components/ActivityHeatmap';
+import StudyPosts from '../components/StudyPosts';
+import LoadingSpinner from '../components/ui/LoadingSpinner';
+import ErrorMessage from '../components/ui/ErrorMessage';
 
 interface UserProfile {
   id: string;
@@ -26,60 +22,14 @@ interface UserProfile {
   updated_at: string;
 }
 
-interface FormData {
-  username: string;
-  full_name: string;
-  icon_url: string;
-  bio: string;
-  scrapbox_project_name: string;
-}
-
-interface TodoSuggestionForm {
-  time_available: number;
-  recent_progress: string;
-  weak_areas: string; // カンマ区切りで入力
-  daily_goal: string;
-}
-
-interface TodoSuggestionResponse {
-  success: boolean;
-  content: string;
-  response_type: string;
-}
-
 export default function ProfilePage() {
   const { user, loading: authLoading } = useAuth();
-  const { addTodos } = useTodos();
   const [profile, setProfile] = useState<UserProfile | null>(null);
-  const [formData, setFormData] = useState<FormData>({
-    username: '',
-    full_name: '',
-    icon_url: '',
-    bio: '',
-    scrapbox_project_name: ''
-  });
   const [loading, setLoading] = useState(true);
-  const [saving, setSaving] = useState(false);
-  const [uploading, setUploading] = useState(false);
   const [error, setError] = useState('');
-  const [editMode, setEditMode] = useState(false);
-  const [useScrapbox, setUseScrapbox] = useState<boolean>(false);
-
-  // TODO提案フォーム用の状態
-  const [todoSuggestionForm, setTodoSuggestionForm] = useState<TodoSuggestionForm>({
-    time_available: 60,
-    recent_progress: '',
-    weak_areas: '',
-    daily_goal: ''
-  });
-  const [todoSuggestionLoading, setTodoSuggestionLoading] = useState(false);
-  const [todoSuggestionResult, setTodoSuggestionResult] = useState<TodoSuggestionResponse | null>(null);
-  const [todoSuggestionError, setTodoSuggestionError] = useState('');
-
 
   const fetchProfile = useCallback(async () => {
     if (!supabase || !user) {
-      // console.log('fetchProfile: Supabaseまたはユーザーが存在しません');
       setLoading(false);
       return;
     }
@@ -94,24 +44,14 @@ export default function ProfilePage() {
         .eq('user_id', user.id)
         .single();
 
-      // console.log('プロフィール取得結果:', { data, error });
-
       if (error) {
         if (error.code === 'PGRST116') {
-          // console.log('プロフィールが存在しないため作成します');
           await createProfile();
         } else {
           throw error;
         }
       } else {
         setProfile(data);
-        setFormData({
-          username: data.username || '',
-          full_name: data.full_name || '',
-          icon_url: data.icon_url || formData.icon_url || profile?.icon_url || '',
-          bio: data.bio || '',
-          scrapbox_project_name: data.scrapbox_project_name || ''
-        });
       }
     } catch (err) {
       console.error('プロフィール取得エラー:', err);
@@ -119,50 +59,22 @@ export default function ProfilePage() {
     } finally {
       setLoading(false);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [user, formData.icon_url, profile?.icon_url]);
-
-  useEffect(() => {
-    if (user && !authLoading) {
-      fetchProfile();
-    } else if (!authLoading) {
-      setLoading(false);
-    }
-  }, [user, authLoading, fetchProfile]);
-
-  useEffect(() => {
-    if (profile?.scrapbox_project_name) {
-      setUseScrapbox(true);
-    } else {
-      setUseScrapbox(false);
-    }
-  }, [profile?.scrapbox_project_name]);
+  }, [user]);
 
   const createProfile = useCallback(async () => {
-    if (!supabase || !user) {
-      // console.log('プロフィール作成: Supabaseまたはユーザーが存在しません');
-      return;
-    }
+    if (!supabase || !user) return;
 
     try {
-      // console.log('プロフィール作成開始:', {
-      //   userId: user.id,
-      //   email: user.email,
-      //   metadata: user.user_metadata
-      // });
-
       const profileData = {
         user_id: user.id,
         username: user.user_metadata?.username || user.email?.split('@')[0] || 'user',
         full_name: user.user_metadata?.full_name || '',
-        icon_url: formData.icon_url || profile?.icon_url || '',
+        icon_url: '',
         bio: '',
-        scrapbox_project_name: formData.scrapbox_project_name || '',
+        scrapbox_project_name: '',
         created_at: new Date().toISOString(),
         updated_at: new Date().toISOString()
       };
-
-      // console.log('作成するプロフィールデータ:', profileData);
 
       const { data, error } = await supabase
         .from('user_profiles')
@@ -175,171 +87,27 @@ export default function ProfilePage() {
         throw error;
       }
 
-      // console.log('プロフィール作成成功:', data);
       setProfile(data);
-      setFormData({
-        username: data.username || '',
-        full_name: data.full_name || '',
-        icon_url: data.icon_url || '',
-        bio: data.bio || '',
-        scrapbox_project_name: data.scrapbox_project_name || ''
-      });
     } catch (err) {
       console.error('プロフィール作成エラー:', err);
-      // より詳細なエラー情報を表示
       if (err instanceof Error) {
         setError(`プロフィールの作成に失敗しました: ${err.message}`);
       } else {
         setError(`プロフィールの作成に失敗しました: ${JSON.stringify(err)}`);
       }
     }
-  }, [user, formData.icon_url, profile?.icon_url, formData.scrapbox_project_name]);
+  }, [user]);
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-
-    if (!user || !formData.username.trim()) {
-      setError('ユーザー名は必須です');
-      return;
+  useEffect(() => {
+    if (user && !authLoading) {
+      fetchProfile();
+    } else if (!authLoading) {
+      setLoading(false);
     }
+  }, [user, authLoading, fetchProfile]);
 
-    try {
-      setSaving(true);
-      setError('');
-
-      const { error } = await supabase!
-        .from('user_profiles')
-        .update({
-          username: formData.username,
-          full_name: formData.full_name,
-          icon_url: formData.icon_url,
-          bio: formData.bio,
-          scrapbox_project_name: formData.scrapbox_project_name,
-          updated_at: new Date().toISOString()
-        })
-        .eq('user_id', user.id);
-
-      if (error) throw error;
-
-      setProfile(prev => prev ? {
-        ...prev,
-        username: formData.username,
-        full_name: formData.full_name,
-        icon_url: formData.icon_url,
-        bio: formData.bio,
-        scrapbox_project_name: formData.scrapbox_project_name,
-        updated_at: new Date().toISOString()
-      } : null);
-
-      setEditMode(false);
-    } catch (err) {
-      console.error('プロフィール更新エラー:', err);
-      setError('プロフィールの更新に失敗しました');
-    } finally {
-      setSaving(false);
-    }
-  };
-
-  const handleCancel = () => {
-    if (profile) {
-      setFormData({
-        username: profile.username || '',
-        full_name: profile.full_name || '',
-        icon_url: profile.icon_url || '',
-        bio: profile.bio || '',
-        scrapbox_project_name: profile.scrapbox_project_name || ''
-      });
-    }
-    setEditMode(false);
-  };
-
-  const handleFileUpload = async (event: React.ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0];
-    if (!file || !user) return;
-
-    try {
-      setUploading(true);
-
-      const fileExt = file.name.split('.').pop();
-      const fileName = `${user.id}.${fileExt}`;
-      const filePath = `${user.id}/${fileName}`;
-
-      // デバッグ用ログ
-      // console.log('アップロードユーザーID:', user.id);
-      // console.log('ファイルパス:', filePath);
-
-      const { error: uploadError } = await supabase!.storage
-        .from('avatars')
-        .upload(filePath, file, {
-          cacheControl: '3600',
-          upsert: true,
-        });
-
-      if (uploadError) throw uploadError;
-
-      const { data: { publicUrl } } = supabase!.storage
-        .from('avatars')
-        .getPublicUrl(filePath);
-
-      setFormData(prev => ({ ...prev, icon_url: publicUrl }));
-    } catch (err) {
-      console.error('画像アップロードエラー:', err);
-      setError('画像のアップロードに失敗しました');
-    } finally {
-      setUploading(false);
-    }
-  };
-
-  const handleTodoSuggestion = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!todoSuggestionForm.time_available || todoSuggestionForm.time_available < 1 || todoSuggestionForm.time_available > 480) {
-      setTodoSuggestionError('勉強時間は1分〜480分の間で指定してください。');
-      return;
-    }
-    try {
-      setTodoSuggestionLoading(true);
-      setTodoSuggestionError('');
-      setTodoSuggestionResult(null);
-
-      let result: TodoSuggestionResponse;
-
-      if (useScrapbox && profile?.scrapbox_project_name) {
-        // Scrapbox連携API
-        result = await generateTodo(
-          profile.scrapbox_project_name,
-          todoSuggestionForm.time_available,
-          todoSuggestionForm.daily_goal
-        );
-      } else {
-        // 通常AI提案API
-        const weakAreasArray = todoSuggestionForm.weak_areas
-          .split(',')
-          .map(s => s.trim())
-          .filter(Boolean);
-        result = await generateGeneralTodo(
-          todoSuggestionForm.time_available,
-          todoSuggestionForm.recent_progress,
-          weakAreasArray,
-          todoSuggestionForm.daily_goal
-        );
-      }
-      setTodoSuggestionResult(result);
-    } catch (_err) {
-      console.error('TODO提案エラー:', _err);
-      setTodoSuggestionError('TODO提案の取得に失敗しました。');
-    } finally {
-      setTodoSuggestionLoading(false);
-    }
-  };
-
-  const handleAddToTodoList = async (todos: CreateTodoItem[]) => {
-    try {
-      await addTodos(todos);
-      alert('TODOリストに追加しました！');
-    } catch (_err) {
-      console.error('TODO追加エラー:', _err);
-      alert('TODOリストへの追加に失敗しました');
-    }
+  const handleProfileUpdate = (updatedProfile: UserProfile) => {
+    setProfile(updatedProfile);
   };
 
   if (authLoading) {
@@ -355,74 +123,17 @@ export default function ProfilePage() {
     );
   }
 
-  if (!user) {
-    return (
-      <div className={css({
-        minH: '100vh',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        bg: 'gray.50'
-      })}>
-        <div className={css({
-          textAlign: 'center',
-          p: '8'
-        })}>
-          <div className={css({
-            w: '16',
-            h: '16',
-            bg: 'red.100',
-            rounded: 'full',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            mx: 'auto',
-            mb: '4'
-          })}>
-            <span className={css({
-              fontSize: '2xl'
-            })}>
-              🔒
-            </span>
-          </div>
-          <h2 className={css({
-            fontSize: 'xl',
-            fontWeight: 'bold',
-            color: 'gray.900',
-            mb: '2'
-          })}>
-            アクセスが拒否されました
-          </h2>
-          <p className={css({
-            color: 'gray.600',
-            mb: '4'
-          })}>
-            このページにアクセスするにはログインが必要です
-          </p>
-        </div>
-      </div>
-    );
-  }
-
   return (
     <main className={css({
-      bg: 'primary.50',
+      bg: 'gray.50',
       minH: '100vh',
       py: '8',
       px: '4'
     })}>
       <div className={css({
-        maxW: '4xl',
+        maxW: '7xl',
         mx: 'auto'
       })}>
-        <h1 className={css({
-          fontSize: '3xl',
-          fontWeight: 'bold',
-          color: 'primary.800',
-          mb: '2'
-        })}>
-          マイページ
-        </h1>
 
         {error && <ErrorMessage message={error} />}
 
@@ -436,565 +147,31 @@ export default function ProfilePage() {
           </div>
         ) : (
           <div className={css({
-            display: 'grid',
-            gridTemplateColumns: { base: '1fr', lg: '1fr 1fr' },
-            gap: '8',
-            maxW: '6xl',
-            mx: 'auto'
+            spaceY: '8'
           })}>
-            {/* プロフィールセクション */}
-            <div>
-              {!editMode && profile ? (
-                // 非編集時のコンパクト表示
-                <div className={css({
-                  bg: 'white',
-                  borderRadius: 'xl',
-                  p: '6',
-                  shadow: 'md',
-                  border: '1px solid',
-                  borderColor: 'primary.100',
-                  h: 'fit-content'
-                })}>
-                  <div className={css({
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'space-between',
-                    mb: '4'
-                  })}>
-                    <h2 className={css({
-                      fontSize: '2xl',
-                      fontWeight: 'bold',
-                      color: 'primary.800'
-                    })}>
-                      プロフィール
-                    </h2>
-                    <button
-                      type="button"
-                      onClick={() => setEditMode(true)}
-                      className={buttonStyles.secondary}
-                    >
-                      編集
-                    </button>
-                  </div>
+            {/* プロフィール情報と最近の投稿 */}
+            <div className={css({
+              display: 'grid',
+              gridTemplateColumns: { base: '1fr', lg: '2fr 1fr' },
+              gap: '8'
+            })}>
+              {/* 左側：プロフィールカード */}
+              <ProfileCard 
+                profile={profile} 
+                user={user}
+                onProfileUpdate={handleProfileUpdate}
+              />
 
-                  <div className={css({
-                    display: 'flex',
-                    alignItems: 'start',
-                    gap: '6'
-                  })}>
-                    {/* プロフィール画像 */}
-                    <div className={css({
-                      w: '20',
-                      h: '20',
-                      rounded: 'full',
-                      overflow: 'hidden',
-                      bg: 'primary.50',
-                      display: 'flex',
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                      border: '2px solid',
-                      borderColor: 'primary.200',
-                      flexShrink: '0'
-                    })}>
-                      {profile.icon_url ? (
-                        <Image
-                          src={profile.icon_url}
-                          alt="プロフィール画像"
-                          width={80}
-                          height={80}
-                          className={css({
-                            w: 'full',
-                            h: 'full',
-                            objectFit: 'cover'
-                          })}
-                        />
-                      ) : (
-                        <span className={css({
-                          fontSize: '3xl',
-                          color: 'primary.300'
-                        })}>
-                          👤
-                        </span>
-                      )}
-                    </div>
-
-                    {/* プロフィール情報 */}
-                    <div className={css({ flex: '1' })}>
-                      <h3 className={css({
-                        fontSize: '2xl',
-                        fontWeight: 'bold',
-                        color: 'gray.900',
-                        mb: '2'
-                      })}>
-                        {profile.username}
-                      </h3>
-
-                      {profile.full_name && (
-                        <p className={css({
-                          fontSize: 'lg',
-                          color: 'primary.600',
-                          mb: '2'
-                        })}>
-                          {profile.full_name}
-                        </p>
-                      )}
-
-                      {profile.bio && (
-                        <p className={css({
-                          color: 'gray.700',
-                          lineHeight: '1.5',
-                          mb: '3'
-                        })}>
-                          {profile.bio}
-                        </p>
-                      )}
-
-                      <div className={css({
-                        display: 'flex',
-                        gap: '4',
-                        fontSize: 'sm',
-                        color: 'gray.500'
-                      })}>
-                        <span>
-                          作成日: {new Date(profile.created_at).toLocaleDateString('ja-JP')}
-                        </span>
-                        {profile.updated_at && profile.updated_at !== profile.created_at && (
-                          <span>
-                            更新日: {new Date(profile.updated_at).toLocaleDateString('ja-JP')}
-                          </span>
-                        )}
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              ) : (
-                // 編集時の詳細フォーム表示
-                <div className={css({
-                  bg: 'white',
-                  rounded: '2xl',
-                  shadow: 'lg',
-                  border: '1px solid',
-                  borderColor: 'gray.100',
-                  p: '8',
-                  h: 'fit-content'
-                })}>
-                  <div className={css({
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'space-between',
-                    mb: '6',
-                    pb: '4',
-                    borderBottom: '1px solid',
-                    borderBottomColor: 'gray.200'
-                  })}>
-                    <h2 className={css({
-                      fontSize: '2xl',
-                      fontWeight: 'bold',
-                      color: 'primary.800'
-                    })}>
-                      プロフィール編集
-                    </h2>
-                  </div>
-
-                  <form onSubmit={handleSubmit}>
-                    {/* プロフィール画像編集 */}
-                    <div className={css({
-                      textAlign: 'center',
-                      mb: '8'
-                    })}>
-                      <div className={css({
-                        position: 'relative',
-                        w: '24',
-                        h: '24',
-                        mx: 'auto',
-                        mb: '4'
-                      })}>
-                        <div className={css({
-                          w: '24',
-                          h: '24',
-                          rounded: 'full',
-                          overflow: 'hidden',
-                          bg: 'primary.50',
-                          display: 'flex',
-                          alignItems: 'center',
-                          justifyContent: 'center',
-                          border: '2px solid',
-                          borderColor: 'primary.200'
-                        })}>
-                          {formData.icon_url ? (
-                            <Image
-                              src={formData.icon_url}
-                              alt="プロフィール画像"
-                              width={80}
-                              height={80}
-                              className={css({
-                                w: 'full',
-                                h: 'full',
-                                objectFit: 'cover'
-                              })}
-                            />
-                          ) : (
-                            <span className={css({
-                              fontSize: '3xl',
-                              color: 'primary.300'
-                            })}>
-                              👤
-                            </span>
-                          )}
-                        </div>
-
-                        <label className={css({
-                          position: 'absolute',
-                          bottom: '0',
-                          right: '0',
-                          w: '8',
-                          h: '8',
-                          bg: 'primary.600',
-                          color: 'white',
-                          rounded: 'full',
-                          display: 'flex',
-                          alignItems: 'center',
-                          justifyContent: 'center',
-                          cursor: 'pointer',
-                          fontSize: 'sm',
-                          border: '2px solid',
-                          borderColor: 'white',
-                          shadow: 'sm',
-                          _hover: {
-                            bg: 'primary.700'
-                          }
-                        })}>
-                          📷
-                          <input
-                            type="file"
-                            accept="image/*"
-                            onChange={handleFileUpload}
-                            className={css({
-                              position: 'absolute',
-                              opacity: '0',
-                              w: 'full',
-                              h: 'full',
-                              cursor: 'pointer'
-                            })}
-                          />
-                        </label>
-                      </div>
-
-                      {uploading && (
-                        <div className={css({
-                          color: 'primary.600',
-                          fontSize: 'sm',
-                          mb: '4'
-                        })}>
-                          アップロード中...
-                        </div>
-                      )}
-
-                      <div className={css({
-                        spaceY: '2'
-                      })}>
-                        <label htmlFor="icon_url_input" className={css({
-                          display: 'block',
-                          fontSize: 'sm',
-                          fontWeight: '600',
-                          color: 'gray.700'
-                        })}>
-                          または、画像URLを直接入力
-                        </label>
-                        <input
-                          id="icon_url_input"
-                          type="url"
-                          placeholder="https://example.com/image.jpg"
-                          value={formData.icon_url}
-                          onChange={(e) => setFormData(prev => ({ ...prev, icon_url: e.target.value }))}
-                          className={formStyles.input}
-                        />
-                      </div>
-                    </div>
-
-                    {/* フォームフィールド */}
-                    <div className={css({
-                      display: 'grid',
-                      gridTemplateColumns: 'repeat(2, 1fr)',
-                      gap: '6',
-                      mb: '6'
-                    })}>
-                      <div>
-                        <label htmlFor="username_input" className={css({
-                          display: 'block',
-                          fontSize: 'sm',
-                          fontWeight: '600',
-                          color: 'gray.700',
-                          mb: '2'
-                        })}>
-                          ユーザー名 *
-                        </label>
-                        <input
-                          id="username_input"
-                          type="text"
-                          value={formData.username}
-                          onChange={(e) => setFormData(prev => ({ ...prev, username: e.target.value }))}
-                          className={formStyles.input}
-                          required
-                        />
-                      </div>
-
-                      <div>
-                        <label htmlFor="full_name_input" className={css({
-                          display: 'block',
-                          fontSize: 'sm',
-                          fontWeight: '600',
-                          color: 'gray.700',
-                          mb: '2'
-                        })}>
-                          フルネーム
-                        </label>
-                        <input
-                          id="full_name_input"
-                          type="text"
-                          value={formData.full_name}
-                          onChange={(e) => setFormData(prev => ({ ...prev, full_name: e.target.value }))}
-                          className={formStyles.input}
-                        />
-                      </div>
-
-                      <div>
-                        <label className={css({
-                          display: 'block',
-                          fontSize: 'sm',
-                          fontWeight: '600',
-                          color: 'gray.700',
-                          mb: '2'
-                        })}>
-                          メールアドレス
-                        </label>
-                        <div className={css({
-                          w: 'full',
-                          px: '3',
-                          py: '2',
-                          bg: 'gray.50',
-                          border: '1px solid',
-                          borderColor: 'gray.200',
-                          rounded: 'md',
-                          fontSize: 'sm',
-                          color: 'gray.600'
-                        })}>
-                          {user.email}
-                        </div>
-                      </div>
-
-                      <div className={css({ gridColumn: 'span 2' })}>
-                        <label htmlFor="scrapbox_project_name_input" className={css({
-                          display: 'block',
-                          fontSize: 'sm',
-                          fontWeight: '600',
-                          color: 'gray.700',
-                          mb: '2'
-                        })}>
-                          Scrapboxプロジェクト名（任意）
-                        </label>
-                        <input
-                          id="scrapbox_project_name_input"
-                          type="text"
-                          placeholder="例: my-study-project"
-                          value={formData.scrapbox_project_name}
-                          onChange={e => setFormData(prev => ({ ...prev, scrapbox_project_name: e.target.value }))}
-                          className={formStyles.input}
-                        />
-                        <div className={css({ fontSize: 'xs', color: 'gray.500', mt: '1' })}>
-                          Scrapboxのプロジェクト名を設定すると、AI TODO提案で活用されます
-                        </div>
-                      </div>
-
-                      <div className={css({ gridColumn: 'span 2' })}>
-                        <label htmlFor="bio_input" className={css({
-                          display: 'block',
-                          fontSize: 'sm',
-                          fontWeight: '600',
-                          color: 'gray.700',
-                          mb: '2'
-                        })}>
-                          自己紹介
-                        </label>
-                        <textarea
-                          id="bio_input"
-                          placeholder="自己紹介を入力してください"
-                          value={formData.bio}
-                          onChange={(e) => setFormData(prev => ({ ...prev, bio: e.target.value }))}
-                          rows={3}
-                          className={formStyles.textarea}
-                        />
-                      </div>
-
-
-                    </div>
-
-                    {/* アクションボタン */}
-                    <div className={css({
-                      display: 'flex',
-                      gap: '3',
-                      justifyContent: 'flex-end',
-                      pt: '4',
-                      borderTop: '1px solid',
-                      borderTopColor: 'gray.200'
-                    })}>
-                      <button
-                        type="button"
-                        onClick={handleCancel}
-                        disabled={saving}
-                        className={buttonStyles.secondary}
-                      >
-                        キャンセル
-                      </button>
-                      <button
-                        type="submit"
-                        disabled={saving || !formData.username.trim()}
-                        className={buttonStyles.primary}
-                      >
-                        {saving ? '保存中...' : '保存'}
-                      </button>
-                    </div>
-                  </form>
-                </div>
+              {/* 右側：最近の学習投稿 */}
+              {user && (
+                <StudyPosts userId={user.id} limit={5} />
               )}
             </div>
 
-            {/* TODO提案セクション */}
-            <div>
-              <div className={css({
-                bg: 'white',
-                borderRadius: 'xl',
-                p: '6',
-                shadow: 'md',
-                border: '1px solid',
-                borderColor: 'primary.100',
-                h: 'fit-content'
-              })}>
-                <h2 className={css({
-                  fontSize: '2xl',
-                  fontWeight: 'bold',
-                  color: 'primary.800',
-                  mb: '4'
-                })}>
-                  今日のTODOリスト提案
-                </h2>
-
-                {/* モード切り替えUI */}
-                {useScrapbox && profile?.scrapbox_project_name ? (
-                  <div className={css({ mb: '4', display: 'flex', alignItems: 'center', gap: '3' })}>
-                    <span className={css({ bg: 'green.100', color: 'green.700', px: '3', py: '1', rounded: 'full', fontSize: 'xs', fontWeight: 'bold' })}>
-                      Scrapbox連携中
-                    </span>
-                    <button type="button" onClick={() => setUseScrapbox(false)} className={css({ ml: 'auto', fontSize: 'xs', color: 'blue.600', bg: 'blue.50', px: '2', py: '1', rounded: 'md', border: 'none', cursor: 'pointer', _hover: { bg: 'blue.100' } })}>
-                      Scrapboxを使わないで詳細入力する
-                    </button>
-                  </div>
-                ) : (
-                  <div className={css({ mb: '4', display: 'flex', alignItems: 'center', gap: '3' })}>
-                    <span className={css({ bg: 'gray.100', color: 'gray.700', px: '3', py: '1', rounded: 'full', fontSize: 'xs', fontWeight: 'bold' })}>
-                      詳細入力モード
-                    </span>
-                    <span className={css({ fontSize: 'xs', color: 'gray.500' })}>
-                      Scrapboxを設定すると「時間」と「今日の目標」だけでTODOリストを提案できます
-                    </span>
-                    {profile?.scrapbox_project_name && (
-                      <button type="button" onClick={() => setUseScrapbox(true)} className={css({ ml: 'auto', fontSize: 'xs', color: 'green.700', bg: 'green.50', px: '2', py: '1', rounded: 'md', border: 'none', cursor: 'pointer', _hover: { bg: 'green.100' } })}>
-                        Scrapboxを使う
-                      </button>
-                    )}
-                  </div>
-                )}
-                <form onSubmit={handleTodoSuggestion} className={css({ spaceY: '4' })}>
-                  <div>
-                    <label htmlFor="todo_time_available" className={css({ display: 'block', fontSize: 'sm', fontWeight: '600', color: 'gray.700', mb: '2' })}>
-                      勉強に使える時間（分）<span className={css({ color: 'red.500' })}>*</span>
-                    </label>
-                    <input
-                      id="todo_time_available"
-                      type="number"
-                      min="1"
-                      max="480"
-                      step="1"
-                      value={todoSuggestionForm.time_available}
-                      onChange={e => setTodoSuggestionForm(prev => ({ ...prev, time_available: parseInt(e.target.value) || 1 }))}
-                      className={formStyles.input}
-                      required
-                    />
-                  </div>
-                  <div>
-                    <label htmlFor="todo_recent_progress" className={css({ display: 'block', fontSize: 'sm', fontWeight: '600', color: 'gray.700', mb: '2' })}>
-                      最近の課題・進捗（任意）
-                    </label>
-                    <textarea
-                      id="todo_recent_progress"
-                      placeholder="例: 英単語の暗記が進んだ、数学の微分が苦手"
-                      value={todoSuggestionForm.recent_progress}
-                      onChange={e => setTodoSuggestionForm(prev => ({ ...prev, recent_progress: e.target.value }))}
-                      rows={2}
-                      className={formStyles.textarea}
-                    />
-                  </div>
-                  <div>
-                    <label htmlFor="todo_weak_areas" className={css({ display: 'block', fontSize: 'sm', fontWeight: '600', color: 'gray.700', mb: '2' })}>
-                      弱点（カンマ区切りで複数入力可・任意）
-                    </label>
-                    <input
-                      id="todo_weak_areas"
-                      type="text"
-                      placeholder="例: リスニング, 文法, 計算ミス"
-                      value={todoSuggestionForm.weak_areas}
-                      onChange={e => setTodoSuggestionForm(prev => ({ ...prev, weak_areas: e.target.value }))}
-                      className={formStyles.input}
-                    />
-                    <div className={css({ fontSize: 'xs', color: 'gray.500', mt: '1' })}>
-                      カンマ区切りで複数入力できます（例: リスニング, 文法, 計算ミス）
-                    </div>
-                  </div>
-                  <div>
-                    <label htmlFor="todo_daily_goal" className={css({ display: 'block', fontSize: 'sm', fontWeight: '600', color: 'gray.700', mb: '2' })}>
-                      今日の目標（任意）
-                    </label>
-                    <textarea
-                      id="todo_daily_goal"
-                      placeholder="例: リスニング問題を10問解く"
-                      value={todoSuggestionForm.daily_goal}
-                      onChange={e => setTodoSuggestionForm(prev => ({ ...prev, daily_goal: e.target.value }))}
-                      rows={2}
-                      className={formStyles.textarea}
-                    />
-                  </div>
-                  {todoSuggestionError && (
-                    <div className={css({ p: '3', bg: 'red.50', border: '1px solid', borderColor: 'red.200', rounded: 'md', color: 'red.700', fontSize: 'sm' })}>
-                      {todoSuggestionError}
-                    </div>
-                  )}
-                  <button
-                    type="submit"
-                    disabled={todoSuggestionLoading || !todoSuggestionForm.time_available}
-                    className={css({ w: 'full', py: '3', px: '4', bg: 'primary.600', color: 'white', rounded: 'md', fontSize: 'sm', fontWeight: 'medium', _hover: { bg: 'primary.700' }, _disabled: { opacity: '0.5', cursor: 'not-allowed' } })}
-                  >
-                    {todoSuggestionLoading ? '提案生成中...' : 'TODOリストを提案してもらう'}
-                  </button>
-                </form>
-
-                {/* 提案結果表示 */}
-                {todoSuggestionResult && (
-                  <div className={css({
-                    mt: '6',
-                    p: '4',
-                    bg: 'green.50',
-                    border: '1px solid',
-                    borderColor: 'green.200',
-                    rounded: 'md'
-                  })}>
-                    <AiTodoSuggestion
-                      content={todoSuggestionResult.content}
-                      onAddTodos={handleAddToTodoList}
-                    />
-                  </div>
-                )}
-              </div>
-            </div>
+            {/* 学習アクティビティヒートマップ */}
+            {user && (
+              <ActivityHeatmap userId={user.id} />
+            )}
           </div>
         )}
       </div>

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,14 +1,16 @@
 'use client';
 
-import { useState, useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useState } from 'react';
+
+import { supabase } from '../../lib/supabase';
 import { css } from '../../styled-system/css';
 import { useAuth } from '../hooks/useAuth';
-import { supabase } from '../../lib/supabase';
-import ProfileCard from '../components/ProfileCard';
+
 import ActivityHeatmap from '../components/ActivityHeatmap';
+import ProfileCard from '../components/ProfileCard';
 import StudyPosts from '../components/StudyPosts';
-import LoadingSpinner from '../components/ui/LoadingSpinner';
 import ErrorMessage from '../components/ui/ErrorMessage';
+import LoadingSpinner from '../components/ui/LoadingSpinner';
 
 interface UserProfile {
   id: string;
@@ -156,11 +158,13 @@ export default function ProfilePage() {
               gap: '8'
             })}>
               {/* 左側：プロフィールカード */}
-              <ProfileCard 
-                profile={profile} 
-                user={user}
-                onProfileUpdate={handleProfileUpdate}
-              />
+              {user && (
+                <ProfileCard 
+                  profile={profile} 
+                  user={user}
+                  onProfileUpdate={handleProfileUpdate}
+                />
+              )}
 
               {/* 右側：最近の学習投稿 */}
               {user && (

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,9 @@
         "next": "15.3.5",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
-        "recharts": "^3.1.0"
+        "react-markdown": "^10.1.0",
+        "recharts": "^3.1.0",
+        "remark-gfm": "^4.0.1"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -2181,12 +2183,38 @@
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
       "license": "MIT"
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
+      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -2200,6 +2228,21 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -2221,7 +2264,6 @@
       "version": "19.1.8",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
       "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -2236,6 +2278,12 @@
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
     },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.6",
@@ -2538,6 +2586,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "license": "ISC"
     },
     "node_modules/@unrs/resolver-binding-android-arm-eabi": {
       "version": "1.11.1",
@@ -3185,6 +3239,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -3374,6 +3438,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -3389,6 +3463,46 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/chokidar": {
@@ -3487,6 +3601,16 @@
       "dependencies": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/concat-map": {
@@ -3638,7 +3762,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/d3-array": {
@@ -3833,7 +3956,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
       "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -3852,6 +3974,19 @@
       "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
       "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.2.0.tgz",
+      "integrity": "sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -3896,6 +4031,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
@@ -3904,6 +4048,19 @@
       "optional": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/doctrine": {
@@ -4639,6 +4796,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
@@ -4660,6 +4827,12 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
@@ -5120,12 +5293,62 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hookable": {
       "version": "5.5.3",
       "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
       "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -5174,6 +5397,12 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.4.tgz",
+      "integrity": "sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q==",
+      "license": "MIT"
+    },
     "node_modules/internal-slot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -5196,6 +5425,30 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-array-buffer": {
@@ -5350,6 +5603,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -5418,6 +5681,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-map": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
@@ -5469,6 +5742,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-regex": {
@@ -6117,6 +6402,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/look-it-up": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/look-it-up/-/look-it-up-2.1.0.tgz",
@@ -6147,6 +6442,16 @@
         "@jridgewell/sourcemap-codec": "^1.5.0"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -6155,6 +6460,288 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.2.tgz",
+      "integrity": "sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.0.tgz",
+      "integrity": "sha512-QGYKEuUsYT9ykKBCMOEDLsU5JRObWQusAolFMeko/tYPufNkRffBAQjIE+99jbA87xv6FgmjLtwjh9wBWajwAA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/merge-anything": {
@@ -6188,6 +6775,569 @@
       "resolved": "https://registry.npmjs.org/microdiff/-/microdiff-1.3.2.tgz",
       "integrity": "sha512-pKy60S2febliZIbwdfEQKTtL5bLNxOyiRRmD400gueYl9XcHyNGxzHSlJWn9IMHwYXT0yohPYL08+bGozVk8cQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/micromatch": {
@@ -6263,7 +7413,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -6637,6 +7786,31 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
     "node_modules/path-browserify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
@@ -6932,6 +8106,16 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -6989,6 +8173,33 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
+    },
+    "node_modules/react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
     },
     "node_modules/react-redux": {
       "version": "9.2.0",
@@ -7111,6 +8322,72 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/require-directory": {
@@ -7553,6 +8830,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/stable-hash": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
@@ -7717,6 +9004,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -7751,6 +9052,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.17.tgz",
+      "integrity": "sha512-xQcBGDxJb6jjFCTzvQtfiPn6YvvP2O8U1MDIPNfJQlWMYfktPy+iGsHE7cssjs7y84d9fQaK4UF3RIJaAHSoYA==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.9"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.9.tgz",
+      "integrity": "sha512-G4qppLgKu/k6FwRpHiGiKPaPTFcG3g4wNVX/Qsfu+RqQM30E7Tyu/TEgxcL9PNLF5pdRLwQdE3YKKf+KF2Dzlw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.4"
       }
     },
     "node_modules/styled-jsx": {
@@ -7921,6 +9240,26 @@
       "license": "MIT",
       "bin": {
         "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/ts-api-utils": {
@@ -8159,6 +9498,93 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
+      "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
+      "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
+      "integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/universalify": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
@@ -8270,6 +9696,34 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.2.tgz",
+      "integrity": "sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/victory-vendor": {
       "version": "37.3.6",
@@ -8523,6 +9977,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
     "next": "15.3.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "recharts": "^3.1.0"
+    "react-markdown": "^10.1.0",
+    "recharts": "^3.1.0",
+    "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",


### PR DESCRIPTION
# プルリクエストの概要

このプルリクエストは、ユーザープロファイルページの**大幅な刷新と機能強化**を目的としています。GitHub風のアクティビティヒートマップ、最近完了したTODOリスト、最近の学習投稿といった新しいUIコンポーネントが導入され、ユーザーの学習進捗と成果をより視覚的に、かつ包括的に表示できるようになります。

---

## 主要な変更点と新機能

### 1. アクティビティヒートマップの導入 (`app/components/ActivityHeatmap.tsx`)

* **GitHubのコントリビューショングラフに似たヒートマップ**が追加されました。
* 過去365日間のTODO完了数を日付ごとに集計し、活動レベルに応じて色分けして表示します。
* 総完了TODO数と連続活動日数（ストリーク）も表示され、ユーザーの学習習慣を可視化します。
* Supabaseから完了済みTODOデータを取得し、日付範囲内のすべての日付を生成してデータを集計します。

### 2. プロフィールカードの改善 (`app/components/ProfileCard.tsx`)

* ユーザーの基本情報を表示する**プロフィールカード**が大幅に更新（または新規追加）されました。
* 詳細な変更内容は不明ですが、ファイルサイズから見て、よりリッチなユーザー情報表示や編集機能が追加された可能性があります。

### 3. 最近完了したTODOリストの表示 (`app/components/RecentTodos.tsx`)

* ユーザーが**最近完了したTODOアイテム**の一覧を表示する新しいコンポーネントが追加されました。
* Supabaseから完了済みのTODOデータを取得し、タイトル、説明、優先度、完了日時、作成日時を表示します。
* 優先度に応じた色のタグ表示や、完了したTODOがない場合のメッセージ、そして「もっと見る」機能が備わっています。

### 4. 最近の学習投稿の表示 (`app/components/StudyPosts.tsx`)

* ユーザーが投稿した**最近の学習記録**を表示する新しいコンポーネントが追加されました。
* `timeline_posts_with_stats`ビューからのデータ取得を試み、存在しない場合は`study_records`テーブルからフォールバックして取得する堅牢なロジックが実装されています。
* 投稿内容、ハッシュタグ、いいね数、コメント数、作成/更新日時などが表示されます。
* 投稿内容は**Markdown形式でレンダリング**され、長い投稿は切り詰め表示と「続きを読む」機能で対応しています。

### 5. Markdownレンダラーの追加 (`app/components/ui/MarkdownRenderer.tsx`)

* Markdown形式のテキストをHTMLとして安全にレンダリングするための**汎用ユーティリティコンポーネント**が追加されました。
* `react-markdown`と`remark-gfm`（GitHub Flavored Markdown）を活用し、コードブロック、テーブル、リストなど、多様なMarkdown記法に対応したスタイリングを提供します。

### 6. プロフィールページの再構築 (`app/profile/page.tsx`)

* 既存の`app/profile/page.tsx`が大幅に書き換えられ、上記の新しく追加されたコンポーネント群を組み込む形で**新しいレイアウトと機能が統合**されました。
* これにより、ユーザーは自分の学習活動、完了したタスク、そして学習記録を一つのページで効果的に確認できるようになります。

### 7. 依存関係の追加 (`package.json`, `package-lock.json`)

* Markdownレンダリング機能を実現するために、**`react-markdown`と`remark-gfm`** のnpmパッケージが新しく依存関係として追加されました。

---

**このプルリクエストにより、ユーザープロファイルは単なる情報表示にとどまらず、学習活動の進捗管理と可視化のための強力なダッシュボードとしての役割を果たすようになります。**