### PR TITLE
目標勉強時間を設定かつグラフ化

### DIFF
--- a/app/components/ProfileCard.tsx
+++ b/app/components/ProfileCard.tsx
@@ -17,6 +17,7 @@ interface UserProfile {
   icon_url?: string;
   bio?: string;
   scrapbox_project_name?: string;
+  target_study_time?: number;
   created_at: string;
   updated_at: string;
 }
@@ -27,6 +28,7 @@ interface FormData {
   icon_url: string;
   bio: string;
   scrapbox_project_name: string;
+  target_study_time: number;
 }
 
 interface User {
@@ -49,7 +51,8 @@ export default function ProfileCard({ profile, user, onProfileUpdate }: ProfileC
     full_name: profile?.full_name || '',
     icon_url: profile?.icon_url || '',
     bio: profile?.bio || '',
-    scrapbox_project_name: profile?.scrapbox_project_name || ''
+    scrapbox_project_name: profile?.scrapbox_project_name || '',
+    target_study_time: profile?.target_study_time || 0
   });
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -72,6 +75,7 @@ export default function ProfileCard({ profile, user, onProfileUpdate }: ProfileC
           icon_url: formData.icon_url,
           bio: formData.bio,
           scrapbox_project_name: formData.scrapbox_project_name,
+          target_study_time: formData.target_study_time,
           updated_at: new Date().toISOString()
         })
         .eq('user_id', user.id);
@@ -85,6 +89,7 @@ export default function ProfileCard({ profile, user, onProfileUpdate }: ProfileC
         icon_url: formData.icon_url,
         bio: formData.bio,
         scrapbox_project_name: formData.scrapbox_project_name,
+        target_study_time: formData.target_study_time,
         updated_at: new Date().toISOString()
       };
 
@@ -105,7 +110,8 @@ export default function ProfileCard({ profile, user, onProfileUpdate }: ProfileC
         full_name: profile.full_name || '',
         icon_url: profile.icon_url || '',
         bio: profile.bio || '',
-        scrapbox_project_name: profile.scrapbox_project_name || ''
+        scrapbox_project_name: profile.scrapbox_project_name || '',
+        target_study_time: profile.target_study_time || 0
       });
     }
     setEditMode(false);
@@ -310,11 +316,31 @@ export default function ProfileCard({ profile, user, onProfileUpdate }: ProfileC
                   fontSize: 'sm',
                   fontWeight: 'medium',
                   border: '1px solid',
-                  borderColor: 'green.200'
+                  borderColor: 'green.200',
+                  mb: '2'
                 })}>
                   📚 Scrapbox: {profile.scrapbox_project_name}
                 </div>
               )}
+
+              {/* 目標勉強時間 */}
+              <div className={css({
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: '2',
+                bg: 'blue.50',
+                color: 'blue.700',
+                px: '3',
+                py: '1',
+                rounded: 'full',
+                fontSize: 'sm',
+                fontWeight: 'medium',
+                border: '1px solid',
+                borderColor: 'blue.200',
+                mb: '2'
+              })}>
+                ⏰ 目標勉強時間: {Math.floor((profile.target_study_time || 0) / 60)}時間{(profile.target_study_time || 0) % 60}分
+              </div>
 
               <div className={css({
                 display: 'flex',
@@ -467,6 +493,29 @@ export default function ProfileCard({ profile, user, onProfileUpdate }: ProfileC
                   mt: '1'
                 })}>
                   設定するとTODO提案機能でScrapboxの情報を活用できます
+                </p>
+              </div>
+
+              <div>
+                <label htmlFor="target_study_time_input" className={formStyles.label}>
+                  1日の目標勉強時間（分）
+                </label>
+                <input
+                  id="target_study_time_input"
+                  type="number"
+                  min="0"
+                  step="15"
+                  placeholder="例: 120（2時間）"
+                  value={formData.target_study_time}
+                  onChange={(e) => setFormData(prev => ({ ...prev, target_study_time: parseInt(e.target.value) || 0 }))}
+                  className={formStyles.input}
+                />
+                <p className={css({
+                  fontSize: 'xs',
+                  color: 'gray.500',
+                  mt: '1'
+                })}>
+                  1日の目標勉強時間を分単位で設定してください（例: 120分 = 2時間）
                 </p>
               </div>
 

--- a/app/components/StudyProgressChart.tsx
+++ b/app/components/StudyProgressChart.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+import React from 'react';
+import { css } from '../../styled-system/css';
+
+interface StudyProgressChartProps {
+  targetMinutes: number;
+  actualMinutes: number;
+  size?: number;
+  label?: string;
+}
+
+export default function StudyProgressChart({ 
+  targetMinutes, 
+  actualMinutes, 
+  size = 120,
+  label = '学習時間'
+}: StudyProgressChartProps) {
+  const radius = size / 2 - 8;
+  const circumference = 2 * Math.PI * radius;
+  
+  // 目標時間が0の場合は100%表示（単純な数値表示用）
+  const progress = targetMinutes === 0 ? 1 : Math.min(actualMinutes / targetMinutes, 1);
+  const strokeDasharray = circumference;
+  const strokeDashoffset = circumference * (1 - progress);
+
+  const getProgressColor = (progress: number, targetMinutes: number) => {
+    // 目標時間が0の場合は青色（単純な数値表示用）
+    if (targetMinutes === 0) return '#3b82f6';
+    
+    if (progress >= 1) return '#10b981'; // 緑色（目標達成）
+    if (progress >= 0.7) return '#3b82f6'; // 青色（良好）
+    if (progress >= 0.4) return '#f59e0b'; // オレンジ色（注意）
+    return '#ef4444'; // 赤色（要改善）
+  };
+
+  const progressColor = getProgressColor(progress, targetMinutes);
+  const progressPercentage = targetMinutes === 0 ? 100 : Math.round(progress * 100);
+
+  return (
+    <div className={css({
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      gap: '3'
+    })}>
+      <div className={css({
+        position: 'relative',
+        w: size,
+        h: size
+      })}>
+        {/* 背景円 */}
+        <svg
+          width={size}
+          height={size}
+          className={css({
+            transform: 'rotate(-90deg)'
+          })}
+        >
+          <circle
+            cx={size / 2}
+            cy={size / 2}
+            r={radius}
+            fill="none"
+            stroke="#e5e7eb"
+            strokeWidth="8"
+          />
+          {/* 進捗円 */}
+          <circle
+            cx={size / 2}
+            cy={size / 2}
+            r={radius}
+            fill="none"
+            stroke={progressColor}
+            strokeWidth="8"
+            strokeLinecap="round"
+            strokeDasharray={strokeDasharray}
+            strokeDashoffset={strokeDashoffset}
+            className={css({
+              transition: 'stroke-dashoffset 0.5s ease-in-out'
+            })}
+          />
+        </svg>
+
+        {/* 中央のテキスト */}
+        <div className={css({
+          position: 'absolute',
+          top: '50%',
+          left: '50%',
+          transform: 'translate(-50%, -50%)',
+          textAlign: 'center'
+        })}>
+          <div className={css({
+            fontSize: '2xl',
+            fontWeight: 'bold',
+            color: progressColor
+          })}>
+            {progressPercentage}%
+          </div>
+          <div className={css({
+            fontSize: 'xs',
+            color: 'gray.600',
+            mt: '1'
+          })}>
+            達成率
+          </div>
+        </div>
+      </div>
+
+      {/* ラベル */}
+      <div className={css({
+        textAlign: 'center'
+      })}>
+        <div className={css({
+          fontSize: 'sm',
+          color: 'gray.600'
+        })}>
+          {label}
+        </div>
+      </div>
+    </div>
+  );
+} 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -33,30 +33,37 @@ export default function DashboardPage() {
     }
   }, [user, authLoading, router]);
 
-  // TODOリストから学習時間を計算（実際のstudy_timeを使用）
+  // 今日完了したTODOの学習時間を計算
   const today = new Date();
-  const todayTodos = todos.filter(todo => {
-    const todoDate = new Date(todo.created_at);
-    return todoDate.toDateString() === today.toDateString();
+  const todayCompletedTodos = todos.filter(todo => {
+    if (todo.status !== 'completed') return false;
+    const completedDate = new Date(todo.updated_at);
+    return completedDate.toDateString() === today.toDateString();
   });
-  const todayTotalMinutes = todayTodos.reduce((total, todo) => total + todo.study_time, 0);
+  const todayTotalMinutes = todayCompletedTodos.reduce((total, todo) => total + todo.study_time, 0);
+  
+  // デバッグ用ログ
+  console.log('今日完了したTODO:', todayCompletedTodos);
+  console.log('今日の合計学習時間（分）:', todayTotalMinutes);
 
-  // 今週の学習時間を計算
+  // 今週完了したTODOの学習時間を計算
   const weekStart = new Date(today);
   weekStart.setDate(today.getDate() - today.getDay());
-  const weekTodos = todos.filter(todo => {
-    const todoDate = new Date(todo.created_at);
-    return todoDate >= weekStart;
+  const weekCompletedTodos = todos.filter(todo => {
+    if (todo.status !== 'completed') return false;
+    const completedDate = new Date(todo.updated_at);
+    return completedDate >= weekStart;
   });
-  const weekTotalMinutes = weekTodos.reduce((total, todo) => total + todo.study_time, 0);
+  const weekTotalMinutes = weekCompletedTodos.reduce((total, todo) => total + todo.study_time, 0);
 
-  // 今月の学習時間を計算
+  // 今月完了したTODOの学習時間を計算
   const monthStart = new Date(today.getFullYear(), today.getMonth(), 1);
-  const monthTodos = todos.filter(todo => {
-    const todoDate = new Date(todo.created_at);
-    return todoDate >= monthStart;
+  const monthCompletedTodos = todos.filter(todo => {
+    if (todo.status !== 'completed') return false;
+    const completedDate = new Date(todo.updated_at);
+    return completedDate >= monthStart;
   });
-  const monthTotalMinutes = monthTodos.reduce((total, todo) => total + todo.study_time, 0);
+  const monthTotalMinutes = monthCompletedTodos.reduce((total, todo) => total + todo.study_time, 0);
 
   // 完了したTODOの数
   const completedTodos = todos.filter(todo => todo.status === 'completed');

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,6 +10,7 @@ import LoadingSpinner from './components/ui/LoadingSpinner';
 import StatCard from './components/StatCard';
 import AiTodoSuggestionCard from './components/AiTodoSuggestionCard';
 import TodoCard from './components/TodoCard';
+import StudyProgressChart from './components/StudyProgressChart';
 import { useAuth } from './hooks/useAuth';
 import { useTodos } from './hooks/useTodos';
 import { sectionStyles } from './styles/components';
@@ -181,31 +182,149 @@ export default function DashboardPage() {
         mx: 'auto'
       })}>
 
-        {/* 統計カード */}
+        {/* スマホ版: 目標達成率のみ */}
         <div className={css({
-          display: 'grid',
-          gridTemplateColumns: { base: '1fr', sm: 'repeat(2, 1fr)', lg: 'repeat(4, 1fr)' },
-          gap: { base: '4', md: '6' },
+          display: { base: 'block', lg: 'none' },
+          mb: '8'
+        })}>
+          <div className={css({
+            bg: 'white',
+            rounded: 'xl',
+            shadow: 'lg',
+            p: '6',
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            border: '1px solid',
+            borderColor: 'gray.100',
+            maxW: 'sm',
+            mx: 'auto'
+          })}>
+            <h3 className={css({
+              fontSize: 'lg',
+              fontWeight: 'bold',
+              color: 'gray.900',
+              mb: '4',
+              textAlign: 'center'
+            })}>
+              今日の目標達成率
+            </h3>
+            <StudyProgressChart
+              targetMinutes={profile?.target_study_time || 120}
+              actualMinutes={todayTotalMinutes}
+              size={140}
+              label="今日の学習時間"
+            />
+          </div>
+        </div>
+
+        {/* PC版: 今月の学習時間・完了済みTODOを円グラフで表示 */}
+        <div className={css({
+          display: { base: 'none', lg: 'grid' },
+          gridTemplateColumns: 'repeat(2, 1fr)',
+          gap: '8',
           mb: '8',
           maxW: '4xl',
           mx: 'auto'
         })}>
-          <StatCard
-            value={`${Math.floor(todayTotalMinutes / 60)}h ${todayTotalMinutes % 60}m`}
-            label="今日の学習時間"
-          />
-          <StatCard
-            value={`${Math.floor(weekTotalMinutes / 60)}h ${weekTotalMinutes % 60}m`}
-            label="今週の学習時間"
-          />
-          <StatCard
-            value={`${Math.floor(monthTotalMinutes / 60)}h ${monthTotalMinutes % 60}m`}
-            label="今月の学習時間"
-          />
-          <StatCard
-            value={completedTodos.length}
-            label="完了したTODO"
-          />
+          {/* 今月の学習時間チャート */}
+          <div className={css({
+            bg: 'white',
+            rounded: 'xl',
+            shadow: 'lg',
+            p: '6',
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            border: '1px solid',
+            borderColor: 'gray.100'
+          })}>
+            <h3 className={css({
+              fontSize: 'lg',
+              fontWeight: 'bold',
+              color: 'gray.900',
+              mb: '4',
+              textAlign: 'center'
+            })}>
+              今月の学習時間
+            </h3>
+            <StudyProgressChart
+              targetMinutes={(profile?.target_study_time || 120) * 30}
+              actualMinutes={monthTotalMinutes}
+              size={140}
+              label="今月の学習時間"
+            />
+            <div className={css({
+              textAlign: 'center',
+              mt: '3'
+            })}>
+              <div className={css({
+                fontSize: 'lg',
+                fontWeight: 'bold',
+                color: 'gray.900'
+              })}>
+                {Math.floor(monthTotalMinutes / 60)}時間{Math.floor(monthTotalMinutes % 60)}分
+              </div>
+              <div className={css({
+                fontSize: 'sm',
+                color: 'gray.600',
+                mt: '1'
+              })}>
+                目標: {Math.floor(((profile?.target_study_time || 120) * 30) / 60)}時間{Math.floor(((profile?.target_study_time || 120) * 30) % 60)}分
+              </div>
+            </div>
+          </div>
+
+          {/* 今日の目標達成率チャート */}
+          <div className={css({
+            bg: 'white',
+            rounded: 'xl',
+            shadow: 'lg',
+            p: '6',
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            border: '1px solid',
+            borderColor: 'gray.100'
+          })}>
+            <h3 className={css({
+              fontSize: 'lg',
+              fontWeight: 'bold',
+              color: 'gray.900',
+              mb: '4',
+              textAlign: 'center'
+            })}>
+              今日の目標達成率
+            </h3>
+            <StudyProgressChart
+              targetMinutes={profile?.target_study_time || 120}
+              actualMinutes={todayTotalMinutes}
+              size={140}
+              label="今日の学習時間"
+            />
+            <div className={css({
+              textAlign: 'center',
+              mt: '3'
+            })}>
+              <div className={css({
+                fontSize: 'lg',
+                fontWeight: 'bold',
+                color: 'gray.900'
+              })}>
+                {Math.floor(todayTotalMinutes / 60)}時間{Math.floor(todayTotalMinutes % 60)}分
+              </div>
+              <div className={css({
+                fontSize: 'sm',
+                color: 'gray.600',
+                mt: '1'
+              })}>
+                目標: {Math.floor((profile?.target_study_time || 120) / 60)}時間{Math.floor((profile?.target_study_time || 120) % 60)}分
+              </div>
+            </div>
+          </div>
         </div>
 
         <div className={css({

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -19,6 +19,7 @@ interface UserProfile {
   icon_url?: string;
   bio?: string;
   scrapbox_project_name?: string;
+  target_study_time?: number;
   created_at: string;
   updated_at: string;
 }
@@ -73,6 +74,7 @@ export default function ProfilePage() {
         icon_url: '',
         bio: '',
         scrapbox_project_name: '',
+        target_study_time: 120, // デフォルト2時間
         created_at: new Date().toISOString(),
         updated_at: new Date().toISOString()
       };

--- a/docs/ADD_TARGET_STUDY_TIME.sql
+++ b/docs/ADD_TARGET_STUDY_TIME.sql
@@ -1,0 +1,13 @@
+-- user_profilesテーブルにtarget_study_timeカラムを追加
+-- 学習目標時間を設定するためのカラム
+
+ALTER TABLE public.user_profiles
+ADD COLUMN IF NOT EXISTS target_study_time NUMERIC NOT NULL DEFAULT 0;
+
+-- 既存のレコードに対してデフォルト値を設定
+UPDATE public.user_profiles 
+SET target_study_time = 0 
+WHERE target_study_time IS NULL;
+
+-- コメントを追加
+COMMENT ON COLUMN public.user_profiles.target_study_time IS 'ユーザーの学習目標時間（分単位）'; 


### PR DESCRIPTION
## 概要
ユーザーが目標勉強時間を設定し、ダッシュボードで進捗を円グラフで表示する機能を実装しました。

## 主な変更点

### 🆕 新機能
- **StudyProgressChartコンポーネント**: 学習進捗を円グラフで表示するコンポーネントを追加
- **目標勉強時間設定**: ProfileCardに目標勉強時間の入力フィールドを追加
- **ダッシュボード進捗表示**: 今日の勉強時間と目標時間を比較した円グラフ進捗表示

### 🗄️ データベース変更
- `user_profiles`テーブルに`target_study_time`カラムを追加
- 目標勉強時間を分単位で保存

### �� UI/UX改善
- ダッシュボードとプロフィールページの中央配置を改善
- レスポンシブデザイン対応（モバイル・PC）
- 時間表示を「時間:分」形式に統一

### �� レスポンシブ対応
- モバイル: 縦並びレイアウト
- PC: 横並びレイアウト
- 円グラフのサイズ調整

## 技術的な詳細

### 新規コンポーネント
- `StudyProgressChart.tsx`: SVGベースの円グラフ進捗表示
- 動的カラーリング（進捗率に応じて色が変化）
- パーセンテージ表示

### データフロー
1. プロフィールページで目標勉強時間を設定
2. Supabaseの`user_profiles`テーブルに保存
3. ダッシュボードで今日の完了TODOの合計時間を取得
4. 目標時間と比較して進捗率を計算
5. 円グラフで視覚的に表示

## ファイル変更一覧

### 新規ファイル
- `app/components/StudyProgressChart.tsx` - 円グラフ進捗表示コンポーネント
- `docs/ADD_TARGET_STUDY_TIME.sql` - データベーススキーマ変更SQL

### 修正ファイル
- `app/components/ProfileCard.tsx` - 目標勉強時間入力フィールド追加
- `app/page.tsx` - ダッシュボードに進捗表示を統合
- `app/profile/page.tsx` - プロフィールページの中央配置改善

## テスト項目
- [ ] 目標勉強時間の設定・保存
- [ ] ダッシュボードでの進捗表示
- [ ] レスポンシブデザイン（モバイル・PC）
- [ ] 時間計算の正確性
- [ ] 円グラフの表示精度

## スクリーンショット
（必要に応じて追加）

## 関連Issue
- 目標勉強時間機能の実装
- ダッシュボード進捗表示の改善
<img width="1216" height="768" alt="スクリーンショット 2025-07-20 11 56 36" src="https://github.com/user-attachments/assets/166e49a2-05c0-4477-9ab9-8dd387ddb9e5" />
<img width="765" height="770" alt="スクリーンショット 2025-07-20 11 57 14" src="https://github.com/user-attachments/assets/58f7afa6-1b9a-4b9c-bd2c-dad886c32a0f" />
